### PR TITLE
Adds code syntax highlighting and concurrent workflow exec to textNode output nodes

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,6 +16,7 @@
         "@vue-flow/node-resizer": "^1.4.0",
         "axios": "^1.7.9",
         "d3": "^7.9.0",
+        "highlight.js": "^11.11.1",
         "install": "^0.13.0",
         "license-checker": "^25.0.1",
         "marked": "^15.0.6",
@@ -2054,6 +2055,15 @@
       "license": "MIT",
       "bin": {
         "he": "bin/he"
+      }
+    },
+    "node_modules/highlight.js": {
+      "version": "11.11.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
+      "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/hookable": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,7 @@
     "@vue-flow/node-resizer": "^1.4.0",
     "axios": "^1.7.9",
     "d3": "^7.9.0",
+    "highlight.js": "^11.11.1",
     "install": "^0.13.0",
     "license-checker": "^25.0.1",
     "marked": "^15.0.6",


### PR DESCRIPTION
This pull request includes several changes to the `frontend` package, focusing on improving the concurrent workflow execution, adding syntax highlighting, and enhancing the user interface for theme selection. The most important changes are summarized below:

### Enhancements to Concurrent Workflow Execution:

* Added a `processed` set to track and prevent double execution of nodes in the `runWorkflowConcurrently` function. (`frontend/src/App.vue`) [[1]](diffhunk://#diff-08bef502d8d33bea18f88fb6f472577fe30ae672500e5429b089c3e9bd686878R394-R396) [[2]](diffhunk://#diff-08bef502d8d33bea18f88fb6f472577fe30ae672500e5429b089c3e9bd686878R417-R426)
* Introduced concurrent execution handling for `textSplitterNode` and `textNode` types, ensuring child nodes are processed concurrently. (`frontend/src/App.vue`)

### Syntax Highlighting and Theme Selection:

* Added `highlight.js` dependency to `package.json` and `package-lock.json` for syntax highlighting. (`frontend/package.json`, `frontend/package-lock.json`) [[1]](diffhunk://#diff-da6498268e99511d9ba0df3c13e439d10556a812881c9d03955b2ef7c6c1c655R20) [[2]](diffhunk://#diff-4a2d9aa3e849b134993936ca81b83fb139edd2b0218077ab0f403b8c4803c62aR19) [[3]](diffhunk://#diff-4a2d9aa3e849b134993936ca81b83fb139edd2b0218077ab0f403b8c4803c62aR2060-R2068)
* Implemented theme selection for syntax highlighting in `ClaudeResponse.vue` and `GeminiResponse.vue`, including the ability to load and switch themes dynamically. (`frontend/src/components/ClaudeResponse.vue`, `frontend/src/components/GeminiResponse.vue`) [[1]](diffhunk://#diff-dca60e5640561242f38a43109555a09eb9ebff34c253d2cdee9a13886b361b81R63-R121) [[2]](diffhunk://#diff-b7b5f1d2c1c84f4001f8a26e767087045585601d98f42153a0c03b34586f8ab6R66-L68)

### Code Refactoring and UI Improvements:

* Refactored `ClaudeResponse.vue` and `GeminiResponse.vue` to use `highlight.js` for code highlighting and added a reactive key to force re-rendering when necessary. (`frontend/src/components/ClaudeResponse.vue`, `frontend/src/components/GeminiResponse.vue`) [[1]](diffhunk://#diff-dca60e5640561242f38a43109555a09eb9ebff34c253d2cdee9a13886b361b81R137-R138) [[2]](diffhunk://#diff-b7b5f1d2c1c84f4001f8a26e767087045585601d98f42153a0c03b34586f8ab6L83-R159)
* Modified the default render mode to `markdown` and added a theme selector in the UI for both `ClaudeResponse.vue` and `GeminiResponse.vue`. (`frontend/src/components/ClaudeResponse.vue`, `frontend/src/components/GeminiResponse.vue`) [[1]](diffhunk://#diff-dca60e5640561242f38a43109555a09eb9ebff34c253d2cdee9a13886b361b81R16-R28) [[2]](diffhunk://#diff-b7b5f1d2c1c84f4001f8a26e767087045585601d98f42153a0c03b34586f8ab6R19-R30)