### PR TITLE
Improves ReAct Agent

### DIFF
--- a/agents.go
+++ b/agents.go
@@ -196,8 +196,6 @@ func (ae *AgentEngine) RunSessionWithHook(ctx context.Context, req ReActRequest,
 		"- code_eval    • run code in sandbox",
 		"- finish       • end and output final answer",
 	)
-	// Explicit guidance for web_content
-	td = append(td, `NOTE → "manifold::web_content" needs {"urls":["https://example.com", "..."]}`)
 
 	sysPrompt := fmt.Sprintf(`You are ReAct-Agent.
 Objective: %s

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -44,9 +44,9 @@
           <ReactAgent v-bind="reactAgentProps" @disable-zoom="disableZoom" @enable-zoom="enableZoom"
             @node-resized="updateNodeDimensions" @contextmenu.native.prevent="showContextMenu($event, reactAgentProps.id)" />
         </template>
-        <template #node-agentNode="agentNodeProps">
-          <AgentNode v-bind="agentNodeProps" @disable-zoom="disableZoom" @enable-zoom="enableZoom"
-            @node-resized="updateNodeDimensions" @contextmenu.native.prevent="showContextMenu($event, agentNodeProps.id)" />
+        <template #node-completions="completionsProps">
+          <AgentNode v-bind="completionsProps" @disable-zoom="disableZoom" @enable-zoom="enableZoom"
+            @node-resized="updateNodeDimensions" @contextmenu.native.prevent="showContextMenu($event, completionsProps.id)" />
         </template>
         <template #node-claudeNode="claudeNodeProps">
           <ClaudeNode v-bind="claudeNodeProps" @contextmenu.native.prevent="showContextMenu($event, claudeNodeProps.id)" />

--- a/frontend/src/components/NodePalette.vue
+++ b/frontend/src/components/NodePalette.vue
@@ -53,7 +53,7 @@ function togglePalette() {
 const nodeCategories = {
   "Text Completions": {
     "reactAgent": null,
-    "agentNode": null,
+    "completions": null,
     "claudeNode": null,
     "geminiNode": null,
     "responseNode": null,

--- a/frontend/src/components/nodes/AgentNode.vue
+++ b/frontend/src/components/nodes/AgentNode.vue
@@ -105,11 +105,11 @@ import BaseAccordion from '@/components/base/BaseAccordion.vue'
 import { useAgentNode } from '@/composables/useAgentNode'
 
 const props = defineProps({
-  id: { type:String, required:true, default:'Agent_0' },
+  id: { type:String, required:true, default:'Completions_0' },
   data:{
     type:Object,
     default:()=>({
-      type:'AgentNode', labelStyle:{ fontWeight:'normal' },
+      type:'Completions', labelStyle:{ fontWeight:'normal' },
       hasInputs:true, hasOutputs:true,
       inputs:{
         endpoint:'',

--- a/frontend/src/components/nodes/AgentNode.vue.d.ts
+++ b/frontend/src/components/nodes/AgentNode.vue.d.ts
@@ -3,7 +3,7 @@ import type { Ref } from 'vue';
 
 // Define the shape of the input prop:
 interface AgentNodeData {
-    type: 'AgentNode';
+    type: 'Completions';
     labelStyle: {
         fontWeight: string;
     };

--- a/frontend/src/composables/useDnD.js
+++ b/frontend/src/composables/useDnD.js
@@ -30,7 +30,6 @@ import MCPClientNode from '../components/nodes/MCPClient.vue'
 import Mermaid from '../components/nodes/Mermaid.vue'
 import CodeRunnerNode from '../components/nodes/CodeRunnerNode.vue'
 import MessageBusNode from '@/components/MessageBusNode.vue'
-import ReactAgentNode from '../components/nodes/ReactAgentNode.vue'
 
 let id = 0
 
@@ -131,7 +130,7 @@ export default function useDragAndDrop() {
       case 'reactAgent':
         component = ReactAgent;
         break;
-      case 'agentNode':
+      case 'completions':
         component = AgentNode;
         break;
       case 'claudeNode':

--- a/stream_agents.go
+++ b/stream_agents.go
@@ -56,7 +56,7 @@ func runReActAgentStreamHandler(cfg *Config) echo.HandlerFunc {
 			DB:         conn,
 			HTTPClient: &http.Client{Timeout: 180 * time.Second},
 			mcpMgr:     mgr,
-			mcpTools:   make(map[string]struct{}),
+			mcpTools:   make(map[string]ToolInfo),
 		}
 
 		// Configure memory engine based on config

--- a/workflows/1_chat_completion.json
+++ b/workflows/1_chat_completion.json
@@ -1,15 +1,15 @@
 {
   "nodes": [
     {
-      "id": "agentNode_e0215bc0-c2af-48a6-b85d-dd635bf074d3",
-      "type": "agentNode",
+      "id": "completions_e0215bc0-c2af-48a6-b85d-dd635bf074d3",
+      "type": "completions",
       "initialized": false,
       "position": {
         "x": 480,
         "y": 96
       },
       "data": {
-        "type": "AgentNode",
+        "type": "completions",
         "labelStyle": {
           "fontWeight": "normal"
         },
@@ -83,7 +83,7 @@
           "height": "400px"
         },
         "connectedTo": [
-          "agentNode_e0215bc0-c2af-48a6-b85d-dd635bf074d3"
+          "completions_e0215bc0-c2af-48a6-b85d-dd635bf074d3"
         ]
       },
       "style": {
@@ -96,7 +96,7 @@
     {
       "id": "edge-0.30367276511116714",
       "type": "step",
-      "source": "agentNode_e0215bc0-c2af-48a6-b85d-dd635bf074d3",
+      "source": "completions_e0215bc0-c2af-48a6-b85d-dd635bf074d3",
       "target": "responseNode_c929cf9e-d61c-4e22-b8c5-56127f2f2a08",
       "sourceHandle": null,
       "targetHandle": "input",

--- a/workflows/2_web_retrieval.json
+++ b/workflows/2_web_retrieval.json
@@ -32,8 +32,8 @@
           "height": "400px"
         },
         "connectedTo": [
-          "agentNode_e0215bc0-c2af-48a6-b85d-dd635bf074d3",
-          "agentNode_a4974c71-d7a9-4ee2-97b3-f34797a01a15"
+          "completions_e0215bc0-c2af-48a6-b85d-dd635bf074d3",
+          "completions_a4974c71-d7a9-4ee2-97b3-f34797a01a15"
         ]
       },
       "style": {
@@ -107,15 +107,15 @@
       }
     },
     {
-      "id": "agentNode_a4974c71-d7a9-4ee2-97b3-f34797a01a15",
-      "type": "agentNode",
+      "id": "completions_a4974c71-d7a9-4ee2-97b3-f34797a01a15",
+      "type": "completions",
       "initialized": false,
       "position": {
         "x": 528,
         "y": 80
       },
       "data": {
-        "type": "AgentNode",
+        "type": "completions",
         "labelStyle": {
           "fontWeight": "normal"
         },
@@ -185,7 +185,7 @@
       "id": "edge-0.5864998088593014",
       "type": "step",
       "source": "webRetrievalNode_8e06a7ee-c06b-45f8-b93f-312beb7b8d55",
-      "target": "agentNode_a4974c71-d7a9-4ee2-97b3-f34797a01a15",
+      "target": "completions_a4974c71-d7a9-4ee2-97b3-f34797a01a15",
       "sourceHandle": "output",
       "targetHandle": null,
       "data": {
@@ -206,7 +206,7 @@
     {
       "id": "edge-0.7743032837178829",
       "type": "step",
-      "source": "agentNode_a4974c71-d7a9-4ee2-97b3-f34797a01a15",
+      "source": "completions_a4974c71-d7a9-4ee2-97b3-f34797a01a15",
       "target": "responseNode_c929cf9e-d61c-4e22-b8c5-56127f2f2a08",
       "sourceHandle": null,
       "targetHandle": "input",

--- a/workflows/3_code_execution.json
+++ b/workflows/3_code_execution.json
@@ -32,8 +32,8 @@
           "height": "400px"
         },
         "connectedTo": [
-          "agentNode_cb711648-501e-4649-a521-d5c14478d45b",
-          "agentNode_d323af38-55bc-4b4c-876f-5a5f513c6bcc"
+          "completions_cb711648-501e-4649-a521-d5c14478d45b",
+          "completions_d323af38-55bc-4b4c-876f-5a5f513c6bcc"
         ]
       },
       "style": {
@@ -120,8 +120,8 @@
           "height": "400px"
         },
         "connectedTo": [
-          "agentNode_8d37ee98-9da9-4617-a54d-2c5bcedd1ce1",
-          "agentNode_21b7d9de-745e-4fe7-b62c-38fe5f0a8b8e"
+          "completions_8d37ee98-9da9-4617-a54d-2c5bcedd1ce1",
+          "completions_21b7d9de-745e-4fe7-b62c-38fe5f0a8b8e"
         ]
       },
       "style": {
@@ -382,15 +382,15 @@
       }
     },
     {
-      "id": "agentNode_d323af38-55bc-4b4c-876f-5a5f513c6bcc",
-      "type": "agentNode",
+      "id": "completions_d323af38-55bc-4b4c-876f-5a5f513c6bcc",
+      "type": "completions",
       "initialized": false,
       "position": {
         "x": -336,
         "y": -192
       },
       "data": {
-        "type": "AgentNode",
+        "type": "completions",
         "labelStyle": {
           "fontWeight": "normal"
         },
@@ -433,15 +433,15 @@
       }
     },
     {
-      "id": "agentNode_21b7d9de-745e-4fe7-b62c-38fe5f0a8b8e",
-      "type": "agentNode",
+      "id": "completions_21b7d9de-745e-4fe7-b62c-38fe5f0a8b8e",
+      "type": "completions",
       "initialized": false,
       "position": {
         "x": 768,
         "y": -192
       },
       "data": {
-        "type": "AgentNode",
+        "type": "completions",
         "labelStyle": {
           "fontWeight": "normal"
         },
@@ -576,7 +576,7 @@
     {
       "id": "edge-0.9164627672653332",
       "type": "smoothstep",
-      "source": "agentNode_d323af38-55bc-4b4c-876f-5a5f513c6bcc",
+      "source": "completions_d323af38-55bc-4b4c-876f-5a5f513c6bcc",
       "target": "responseNode_2c8b5e4f-4a7b-448d-af30-4867fa3bb9cc",
       "sourceHandle": null,
       "targetHandle": "input",
@@ -599,7 +599,7 @@
       "id": "edge-0.657478969239189",
       "type": "smoothstep",
       "source": "responseNode_7ba4273a-9f29-4006-bc44-b7f104c9bcb8",
-      "target": "agentNode_d323af38-55bc-4b4c-876f-5a5f513c6bcc",
+      "target": "completions_d323af38-55bc-4b4c-876f-5a5f513c6bcc",
       "sourceHandle": "output",
       "targetHandle": null,
       "data": {
@@ -621,7 +621,7 @@
       "id": "edge-0.9322679126045987",
       "type": "smoothstep",
       "source": "responseNode_2c8b5e4f-4a7b-448d-af30-4867fa3bb9cc",
-      "target": "agentNode_21b7d9de-745e-4fe7-b62c-38fe5f0a8b8e",
+      "target": "completions_21b7d9de-745e-4fe7-b62c-38fe5f0a8b8e",
       "sourceHandle": "output",
       "targetHandle": null,
       "data": {
@@ -643,7 +643,7 @@
       "id": "edge-0.852993591748597",
       "type": "smoothstep",
       "source": "responseNode_7ba4273a-9f29-4006-bc44-b7f104c9bcb8",
-      "target": "agentNode_21b7d9de-745e-4fe7-b62c-38fe5f0a8b8e",
+      "target": "completions_21b7d9de-745e-4fe7-b62c-38fe5f0a8b8e",
       "sourceHandle": "output",
       "targetHandle": null,
       "data": {
@@ -665,7 +665,7 @@
       "id": "edge-0.22569120544751642",
       "type": "smoothstep",
       "source": "responseNode_78168f32-9d95-47e4-9f8a-35303e146f8d",
-      "target": "agentNode_21b7d9de-745e-4fe7-b62c-38fe5f0a8b8e",
+      "target": "completions_21b7d9de-745e-4fe7-b62c-38fe5f0a8b8e",
       "sourceHandle": "output",
       "targetHandle": null,
       "data": {
@@ -686,7 +686,7 @@
     {
       "id": "edge-0.13071522253053924",
       "type": "smoothstep",
-      "source": "agentNode_21b7d9de-745e-4fe7-b62c-38fe5f0a8b8e",
+      "source": "completions_21b7d9de-745e-4fe7-b62c-38fe5f0a8b8e",
       "target": "responseNode_c6badd8d-fa56-4865-a237-78642db2d835",
       "sourceHandle": null,
       "targetHandle": "input",


### PR DESCRIPTION
This pull request introduces significant updates to the `AgentEngine` structure, improves the handling of conversation history in the agent workflow, and refactors the frontend to rename and standardize node types. Below are the key changes grouped by theme:

### Backend Changes

#### Enhancements to `AgentEngine` and MCP Tool Handling:
* Replaced `map[string]struct{}` with `map[string]ToolInfo` for `mcpTools` in `AgentEngine`, enabling storage of metadata such as tool name, description, and input schema. Added a new `ToolInfo` struct to support this change. (`agents.go`, [[1]](diffhunk://#diff-6ca6a8235dd83e6ba410ffc3750b480daa53cc3795227323dcd3a4c170ca2eb7L74-R73) [[2]](diffhunk://#diff-6ca6a8235dd83e6ba410ffc3750b480daa53cc3795227323dcd3a4c170ca2eb7L116-R115) [[3]](diffhunk://#diff-6ca6a8235dd83e6ba410ffc3750b480daa53cc3795227323dcd3a4c170ca2eb7R146-R196) [[4]](diffhunk://#diff-155d616767bdb0ea5dc73707a7587f30339d01cf5e57e37dab70e69b98bfe326L59-R59)
* Updated the `discoverMCPTools` method to process MCP tool data and populate the `ToolInfo` map with detailed metadata. (`agents.go`, [agents.goR146-R196](diffhunk://#diff-6ca6a8235dd83e6ba410ffc3750b480daa53cc3795227323dcd3a4c170ca2eb7R146-R196))

#### Improvements to Conversation Handling:
* Introduced `conversationHistory` to persist system, assistant, and user messages across turns, ensuring context is maintained throughout the session. (`agents.go`, [[1]](diffhunk://#diff-6ca6a8235dd83e6ba410ffc3750b480daa53cc3795227323dcd3a4c170ca2eb7R282-R292) [[2]](diffhunk://#diff-6ca6a8235dd83e6ba410ffc3750b480daa53cc3795227323dcd3a4c170ca2eb7L280-R321) [[3]](diffhunk://#diff-6ca6a8235dd83e6ba410ffc3750b480daa53cc3795227323dcd3a4c170ca2eb7R405-R419)
* Adjusted the logic in `callLLM` to dynamically calculate `maxTokens` based on the model's context size and input token count. (`agents.go`, [agents.goL398-R451](diffhunk://#diff-6ca6a8235dd83e6ba410ffc3750b480daa53cc3795227323dcd3a4c170ca2eb7L398-R451))

#### Cleanup and Refactoring:
* Removed the unused `reflect` import and the `extractToolName` helper function, simplifying the codebase. (`agents.go`, [[1]](diffhunk://#diff-6ca6a8235dd83e6ba410ffc3750b480daa53cc3795227323dcd3a4c170ca2eb7L15) [[2]](diffhunk://#diff-6ca6a8235dd83e6ba410ffc3750b480daa53cc3795227323dcd3a4c170ca2eb7R146-R196)

### Frontend Changes

#### Node Type Standardization:
* Renamed `agentNode` to `completions` across the frontend components and workflows for consistency:
  - Updated Vue components such as `App.vue` and `NodePalette.vue` to reflect the new naming convention. (`frontend/src/App.vue`, [[1]](diffhunk://#diff-08bef502d8d33bea18f88fb6f472577fe30ae672500e5429b089c3e9bd686878L47-R49); `frontend/src/components/NodePalette.vue`, [[2]](diffhunk://#diff-1be01e951b018e4282e779f78e866d70ce4a31ed934464e9072633899aedbe39L56-R56)
  - Adjusted workflows JSON files to replace references to `agentNode` with `completions`. (`workflows/1_chat_completion.json`, [[1]](diffhunk://#diff-7a62bfa37f8fdecadb3f7801164ab165bb401a94a24f9efb3aaafd3dea55cdcaL4-R12); `workflows/2_web_retrieval.json`, [[2]](diffhunk://#diff-a304e55ea03256db22fb5ce63b12d12cc8d30660a015019fe809f5b4f7739d38L35-R36); `workflows/3_code_execution.json`, [[3]](diffhunk://#diff-4113e9040cd464fe585a8ab07527915e3c2fee1f58c1ea4be003dfa41962c982L35-R36)

#### Component Updates:
* Modified the default `id` and `type` properties in `AgentNode.vue` to align with the new `completions` naming. (`frontend/src/components/nodes/AgentNode.vue`, [frontend/src/components/nodes/AgentNode.vueL108-R112](diffhunk://#diff-f5a69944cf47a190f322a7bb15fb40516900dea84bd8d1d3137dff8053035021L108-R112))
* Removed unused imports, such as `ReactAgentNode`, from the frontend code. (`frontend/src/composables/useDnD.js`, [frontend/src/composables/useDnD.jsL33](diffhunk://#diff-97eba10d4f002f7986c310f29cf246f0b39eb2e3392b31a8a86b552fa7a4a5baL33))

These changes enhance the backend's extensibility and maintainability while improving the frontend's consistency and usability.