### PR TITLE
Fix GPU info parsing

### DIFF
--- a/hostinfo.go
+++ b/hostinfo.go
@@ -111,11 +111,17 @@ func parseMacOSGPUInfo(input string) ([]GPUInfo, error) {
 				gpus = append(gpus, currentGPU)
 				currentGPU = GPUInfo{}
 			}
-			currentGPU.Model = strings.TrimSpace(strings.Split(line, ":")[1])
+			if parts := strings.SplitN(line, ":", 2); len(parts) == 2 {
+				currentGPU.Model = strings.TrimSpace(parts[1])
+			}
 		} else if strings.HasPrefix(line, "Total Number of Cores") {
-			currentGPU.TotalNumberOfCores = strings.TrimSpace(strings.Split(line, ":")[1])
+			if parts := strings.SplitN(line, ":", 2); len(parts) == 2 {
+				currentGPU.TotalNumberOfCores = strings.TrimSpace(parts[1])
+			}
 		} else if strings.HasPrefix(line, "Metal") {
-			currentGPU.MetalSupport = strings.TrimSpace(strings.Split(line, ":")[1])
+			if parts := strings.SplitN(line, ":", 2); len(parts) == 2 {
+				currentGPU.MetalSupport = strings.TrimSpace(parts[1])
+			}
 		}
 	}
 

--- a/hostinfo_test.go
+++ b/hostinfo_test.go
@@ -50,3 +50,15 @@ Metal: Supported
 		t.Errorf("second GPU data mismatch: %+v", gpus[1])
 	}
 }
+func TestParseMacOSGPUInfo_MalformedLines(t *testing.T) {
+	input := `Chipset Model Intel Graphics
+Total Number of Cores
+Metal`
+	gpus, err := parseMacOSGPUInfo(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(gpus) != 1 {
+		t.Fatalf("expected 1 GPU, got %d", len(gpus))
+	}
+}


### PR DESCRIPTION
## Summary
- avoid index out-of-range when parsing macOS GPU info
- add regression test for malformed GPU info lines

## Testing
- `go test ./...` *(fails: no route to host when fetching modules)*