### PR TITLE
Refactor WebSearch node

### DIFF
--- a/frontend/src/components/nodes/WebSearchNode.vue
+++ b/frontend/src/components/nodes/WebSearchNode.vue
@@ -1,11 +1,8 @@
 <template>
-  <div
-    :style="computedContainerStyle"
-    class="flex flex-col w-full h-full p-3 rounded-xl border border-gray-600 bg-zinc-900 text-gray-100 shadow"
-    @mouseenter="isHovered = true"
-    @mouseleave="isHovered = false"
-  >
-    <div :style="data.labelStyle" class="node-label text-base font-semibold mb-2">{{ data.type }}</div>
+  <BaseNode :id="id" :data="data" :min-height="220" @resize="onResize">
+    <template #header>
+      <div :style="data.labelStyle" class="node-label text-base font-semibold">{{ data.type }}</div>
+    </template>
 
     <BaseInput
       :id="`${data.id}-query`"
@@ -54,27 +51,16 @@
       @blur="onInputBlur"
     />
 
-    <Handle style="width:12px; height:12px" v-if="data.hasInputs" type="target" position="left" />
-    <Handle style="width:12px; height:12px" v-if="data.hasOutputs" type="source" position="right" />
-
-    <NodeResizer
-      :is-resizable="true"
-      :color="'#666'"
-      :handle-style="resizeHandleStyle"
-      :line-style="resizeHandleStyle"
-      :min-width="320"
-      :min-height="180"
-      :node-id="id"
-      @resize="onResize"
-    />
-  </div>
+    <Handle style="width:12px;height:12px" v-if="data.hasInputs" type="target" position="left" />
+    <Handle style="width:12px;height:12px" v-if="data.hasOutputs" type="source" position="right" />
+  </BaseNode>
 </template>
 
 <script setup>
-import { Handle, useVueFlow } from '@vue-flow/core'
-import { NodeResizer } from '@vue-flow/node-resizer'
+import { Handle } from '@vue-flow/core'
 import BaseInput from '@/components/base/BaseInput.vue'
 import BaseSelect from '@/components/base/BaseSelect.vue'
+import BaseNode from '@/components/base/BaseNode.vue'
 import { useWebSearch } from '../../composables/useWebSearch'
 
 const props = defineProps({
@@ -98,17 +84,20 @@ const props = defineProps({
         sxngUrl: '',
       },
       outputs: {},
+      style: {
+        border: '1px solid #666',
+        borderRadius: '12px',
+        backgroundColor: '#333',
+        color: '#eee',
+        width: '360px',
+        height: '220px'
+      },
     }),
   },
 })
 
 const emit = defineEmits(['update:data', 'resize', 'disable-zoom', 'enable-zoom'])
-const vueFlowInstance = useVueFlow()
 const {
-  isHovered,
-  customStyle,
-  resizeHandleStyle,
-  computedContainerStyle,
   query,
   resultSize,
   searchBackend,
@@ -119,7 +108,7 @@ const {
   onInputFocus,
   onInputBlur,
   onResize
-} = useWebSearch(props, emit, vueFlowInstance)
+} = useWebSearch(props, emit)
 </script>
 
 <style scoped>

--- a/frontend/src/composables/useWebSearch.js
+++ b/frontend/src/composables/useWebSearch.js
@@ -1,14 +1,45 @@
-import { ref, watch } from 'vue'
+import { ref, watch, onMounted } from 'vue'
 import { useVueFlow } from '@vue-flow/core'
+import { useNodeBase } from './useNodeBase'
 
 export function useWebSearch(props, emit) {
   const { getEdges, findNode } = useVueFlow()
+
+  // Basic node UI behaviour and resize handling
+  const {
+    isHovered,
+    customStyle,
+    resizeHandleStyle,
+    computedContainerStyle,
+    onResize
+  } = useNodeBase(props, emit)
 
   // Reactive state
   const query = ref(props.data.inputs?.query || '')
   const resultSize = ref(props.data.inputs?.result_size || 1)
   const searchBackend = ref(props.data.inputs?.search_backend || 'ddg')
   const sxngUrl = ref(props.data.inputs?.sxng_url || 'https://searx.be')
+
+  const searchBackendOptions = [
+    { value: 'ddg', label: 'DuckDuckGo' },
+    { value: 'sxng', label: 'SearXNG' }
+  ]
+
+  function onInputMouseDown() {
+    emit && emit('disable-zoom')
+  }
+
+  function onInputMouseUp() {
+    emit && emit('enable-zoom')
+  }
+
+  function onInputFocus() {
+    emit && emit('disable-zoom')
+  }
+
+  function onInputBlur() {
+    emit && emit('enable-zoom')
+  }
 
   // Main run function
   async function run() {
@@ -107,11 +138,42 @@ export function useWebSearch(props, emit) {
     }
   }
 
+  onMounted(() => {
+    setup()
+    if (!props.data.style) {
+      props.data.style = {
+        border: '1px solid #666',
+        borderRadius: '12px',
+        backgroundColor: '#333',
+        color: '#eee',
+        width: '360px',
+        height: '220px'
+      }
+    }
+    customStyle.value.width = props.data.style.width || '360px'
+    customStyle.value.height = props.data.style.height || '220px'
+  })
+
   return {
+    // state
     query,
     resultSize,
     searchBackend,
     sxngUrl,
+    searchBackendOptions,
+    isHovered,
+    resizeHandleStyle,
+    computedContainerStyle,
+    customStyle,
+
+    // handlers
+    onInputMouseDown,
+    onInputMouseUp,
+    onInputFocus,
+    onInputBlur,
+    onResize,
+
+    // methods
     updateNodeData,
     run,
     setup


### PR DESCRIPTION
## Summary
- refactor `WebSearchNode.vue` to use `BaseNode` like `AgentNode`
- improve `useWebSearch.js` composable with `useNodeBase` and Tailwind-friendly helpers

## Testing
- `go test ./...` *(fails: proxyconnect tcp: dial tcp 172.26.0.3:8080: connect: no route to host)*