### PR TITLE
feat: implement chat store for managing messages and configuration

### DIFF
--- a/frontend/src/stores/chatStore.ts
+++ b/frontend/src/stores/chatStore.ts
@@ -1,0 +1,68 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+
+export interface ChatMessage {
+  role: string;
+  content: string;
+}
+
+export const useChatStore = defineStore('chat', () => {
+  // Chat messages
+  const messages = ref<ChatMessage[]>([])
+  
+  // Chat configuration
+  const provider = ref('llama-server')
+  const endpoint = ref('http://localhost:8080/api/v1/chat/completions')
+  const api_key = ref('')
+  const model = ref('local')
+  const max_completion_tokens = ref(8192)
+  const temperature = ref(0.6)
+  const enableToolCalls = ref(false)
+  const selectedSystemPrompt = ref('friendly_assistant')
+  const system_prompt = ref('')
+  
+  // UI preferences
+  const renderMode = ref('markdown')
+  const selectedTheme = ref('atom-one-dark')
+
+  // Methods to update chat state
+  function addMessage(message: ChatMessage) {
+    messages.value.push(message)
+  }
+  
+  function updateLastAssistantMessage(content: string) {
+    for (let i = messages.value.length - 1; i >= 0; i--) {
+      if (messages.value[i].role === 'assistant') {
+        messages.value[i].content = content
+        break
+      }
+    }
+  }
+  
+  function clearMessages() {
+    messages.value = []
+  }
+  
+  function setSystemPrompt(prompt: string) {
+    system_prompt.value = prompt
+  }
+
+  return { 
+    messages, 
+    provider,
+    endpoint,
+    api_key,
+    model,
+    max_completion_tokens,
+    temperature,
+    enableToolCalls,
+    selectedSystemPrompt,
+    system_prompt,
+    renderMode,
+    selectedTheme,
+    addMessage,
+    updateLastAssistantMessage,
+    clearMessages,
+    setSystemPrompt
+  }
+})


### PR DESCRIPTION
This pull request refactors the `Chat.vue` component to use a centralized `chatStore` for managing chat state and configuration, improving code maintainability and reactivity. It also introduces a new Pinia store (`chatStore`) to encapsulate chat-related data and methods. The most important changes include replacing local state in `Chat.vue` with computed properties tied to `chatStore`, adding helper methods to manage chat messages, and updating the message handling logic.

### Refactoring to use `chatStore`:
* Replaced local `ref` variables in `Chat.vue` (e.g., `messages`, `provider`, `endpoint`) with `computed` properties tied to the `chatStore` for better state management. (`frontend/src/Chat.vue`: [[1]](diffhunk://#diff-eda7f472e043fedce02f08e273e9b91925c3396d393d4a168395f7faf94b20f5R74-R82) [[2]](diffhunk://#diff-eda7f472e043fedce02f08e273e9b91925c3396d393d4a168395f7faf94b20f5L93-R176)
* Updated the `sendMessage` function to use `chatStore` methods (`addMessage`, `updateLastAssistantMessage`) instead of directly modifying the `messages` array. (`frontend/src/Chat.vue`: [[1]](diffhunk://#diff-eda7f472e043fedce02f08e273e9b91925c3396d393d4a168395f7faf94b20f5L161-R223) [[2]](diffhunk://#diff-eda7f472e043fedce02f08e273e9b91925c3396d393d4a168395f7faf94b20f5R237-R247)

### New `chatStore` implementation:
* Introduced a new Pinia store (`chatStore`) in `chatStore.ts` to centralize chat-related state, including messages, configuration, and UI preferences. (`frontend/src/stores/chatStore.ts`: [frontend/src/stores/chatStore.tsR1-R68](diffhunk://#diff-c418dba53de7c8cc64c57f48a99f846aba8d33645fbb0b6483b83582d18fa2d5R1-R68))
* Added methods to `chatStore` for managing chat state, such as `addMessage`, `updateLastAssistantMessage`, and `setSystemPrompt`. (`frontend/src/stores/chatStore.ts`: [frontend/src/stores/chatStore.tsR1-R68](diffhunk://#diff-c418dba53de7c8cc64c57f48a99f846aba8d33645fbb0b6483b83582d18fa2d5R1-R68))

### Additional improvements:
* Ensured reactivity is preserved by replacing deep watches and manual updates with computed properties and store methods. (`frontend/src/Chat.vue`: [frontend/src/Chat.vueL152-R210](diffhunk://#diff-eda7f472e043fedce02f08e273e9b91925c3396d393d4a168395f7faf94b20f5L152-R210))
* Initialized `system_prompt` in `chatStore` if not already set, based on the selected system prompt. (`frontend/src/Chat.vue`: [frontend/src/Chat.vueL93-R176](diffhunk://#diff-eda7f472e043fedce02f08e273e9b91925c3396d393d4a168395f7faf94b20f5L93-R176))