### PR TITLE
Optimize tool agent prompt usage

### DIFF
--- a/internal/agents/stream.go
+++ b/internal/agents/stream.go
@@ -71,7 +71,7 @@ func RunReActAgentStreamHandler(cfg *configpkg.Config) echo.HandlerFunc {
 
 			// Flush to ensure client receives it immediately
 			flusher.Flush()
-		})
+		}, false)
 		if err != nil {
 			return c.String(http.StatusInternalServerError, err.Error())
 		}


### PR DESCRIPTION
## Summary
- ensure orchestrator only sees concise instructions for each tool-agent
- list full tool schemas only when running tool agents directly
- add a flag for including tool schemas in RunSessionWithHook

## Testing
- `go test ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_686c8e7ba8348328bed227e3063b0439