### PR TITLE
feat: Add reachability checks for embedding service

### DIFF
--- a/internal/agentd/run.go
+++ b/internal/agentd/run.go
@@ -210,6 +210,9 @@ func newApp(ctx context.Context, cfg *config.Config) (*app, error) {
 	// RAG tools backed by internal/rag Service
 	// Create a real embedder using the configured embedding service
 	emb := embedder.NewClient(cfg.Embedding, cfg.Databases.Vector.Dimensions)
+	if err := emb.Ping(ctx); err != nil {
+		return nil, fmt.Errorf("embedding service reachability check failed: %w", err)
+	}
 	toolRegistry.Register(ragtool.NewIngestTool(mgr, ragservice.WithEmbedder(emb)))
 	toolRegistry.Register(ragtool.NewRetrieveTool(mgr, ragservice.WithEmbedder(emb)))
 

--- a/internal/embedding/client.go
+++ b/internal/embedding/client.go
@@ -80,6 +80,16 @@ func EmbedText(ctx context.Context, cfg config.EmbeddingConfig, inputs []string)
 	return out, nil
 }
 
+// CheckReachability verifies that the embedding endpoint is reachable and
+// responding correctly by sending a small test request.
+func CheckReachability(ctx context.Context, cfg config.EmbeddingConfig) error {
+	_, err := EmbedText(ctx, cfg, []string{"ping"})
+	if err != nil {
+		return fmt.Errorf("embedding endpoint reachability check failed: %w", err)
+	}
+	return nil
+}
+
 func min(a, b int) int {
 	if a < b {
 		return a

--- a/internal/rag/embedder/embedder.go
+++ b/internal/rag/embedder/embedder.go
@@ -19,6 +19,8 @@ type Embedder interface {
 	Name() string
 	// Dimension returns the embedding dimensionality (0 for variable/unknown).
 	Dimension() int
+	// Ping checks if the embedding service is reachable.
+	Ping(ctx context.Context) error
 }
 
 // clientEmbedder wraps the embedding.EmbedText HTTP client for real embeddings.
@@ -47,6 +49,10 @@ func NewClient(cfg config.EmbeddingConfig, dim int) Embedder {
 
 func (c *clientEmbedder) Name() string   { return c.cfg.Model }
 func (c *clientEmbedder) Dimension() int { return c.dim }
+
+func (c *clientEmbedder) Ping(ctx context.Context) error {
+	return embedding.CheckReachability(ctx, c.cfg)
+}
 
 func (c *clientEmbedder) EmbedBatch(ctx context.Context, texts []string) ([][]float32, error) {
 	if len(texts) == 0 {
@@ -110,6 +116,8 @@ func NewDeterministic(dim int, normalize bool, seed uint64) Embedder {
 
 func (d *deterministicEmbedder) Name() string   { return d.name }
 func (d *deterministicEmbedder) Dimension() int { return d.dim }
+
+func (d *deterministicEmbedder) Ping(_ context.Context) error { return nil }
 
 func (d *deterministicEmbedder) EmbedBatch(_ context.Context, texts []string) ([][]float32, error) {
 	out := make([][]float32, len(texts))


### PR DESCRIPTION
Quick change to ping configured embeddings endpoint and fail application startup if unreachable. Embeddings are required for Manifold to properly utilize its feature set.