### PR TITLE
add basic config defaults

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,16 +33,6 @@ jobs:
         with:
           go-version: ${{ matrix.go-version }}
 
-      - name: Cache Go modules
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ matrix.go-version }}-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-${{ matrix.go-version }}-
-
       - name: Ensure modules tidy
         run: go mod tidy
 

--- a/config.yaml.basic
+++ b/config.yaml.basic
@@ -1,0 +1,28 @@
+# Minimal first-run Manifold config.
+#
+# No YAML keys are required for a default local install. Manifold will use:
+# - workdir: $HOME/.manifold/projects, created on startup when omitted
+# - llm_client.provider: openai, unless only ANTHROPIC_API_KEY or
+#   GOOGLE_LLM_API_KEY / GOOGLE_API_KEY is set
+# - databases.backend: sqlite
+# - memory.enabled: false, with memory subsystems configured and ready
+# - harness.enabled: false
+# - embedding: OpenAI text-embedding-3-small
+# - imageTool: OpenAI-compatible gpt-5.4-mini
+# - reranking.enabled: false
+#
+# Set one provider key in your environment, then run Manifold:
+#   OPENAI_API_KEY=...
+#   ANTHROPIC_API_KEY=...
+#   GOOGLE_LLM_API_KEY=...
+#
+# To force a provider when multiple keys are present, uncomment one block:
+#
+# llm_client:
+#   provider: openai
+#
+# llm_client:
+#   provider: anthropic
+#
+# llm_client:
+#   provider: google

--- a/internal/agentd/app_init_tools.go
+++ b/internal/agentd/app_init_tools.go
@@ -237,14 +237,9 @@ func initTransitService(cfg *config.Config, mgr databases.Manager, runtimeRAGSer
 
 func registerImageTool(cfg *config.Config, httpClient *http.Client, llm llmpkg.Provider, toolRegistry tools.Registry) {
 	newProv := func(baseURL string) llmpkg.Provider {
-		switch cfg.LLMClient.Provider {
-		case "", "openai", "local":
-			cfgCopy := cfg.LLMClient.OpenAI
-			cfgCopy.BaseURL = baseURL
-			return openaillm.New(cfgCopy, httpClient)
-		default:
-			return llm
-		}
+		cfgCopy := cfg.LLMClient.OpenAI
+		cfgCopy.BaseURL = baseURL
+		return openaillm.New(cfgCopy, httpClient)
 	}
 	toolRegistry.Register(imagetool.NewDescribeTool(llm, cfg.Workdir, cfg.ImageTool.Model, cfg.ImageTool.BaseURL, newProv))
 }

--- a/internal/agentd/chat_engine_builders_test.go
+++ b/internal/agentd/chat_engine_builders_test.go
@@ -54,6 +54,14 @@ func buildOrchestratorTestRequest(sessionID, systemPromptOverride string, owner 
 	}
 }
 
+func enabledChatMemoryRunSettings() chatMemoryRunSettings {
+	return chatMemoryRunSettings{
+		MemoryEnabled:         true,
+		EvolvingMemoryEnabled: true,
+		BeliefMemoryEnabled:   true,
+	}
+}
+
 func TestBuildSpecialistChatEngineUsesOverrideAndSkills(t *testing.T) {
 	t.Parallel()
 
@@ -72,7 +80,9 @@ func TestBuildSpecialistChatEngineUsesOverrideAndSkills(t *testing.T) {
 	}
 	app.invalidateSpecialistsCache(ctx, 7)
 
-	result := app.buildSpecialistChatEngine(ctx, buildSpecialistTestRequest("alpha", "override system", "sess-1", 7))
+	req := buildSpecialistTestRequest("alpha", "override system", "sess-1", 7)
+	req.MemorySettings = enabledChatMemoryRunSettings()
+	result := app.buildSpecialistChatEngine(ctx, req)
 	if result.Err != nil {
 		t.Fatalf("buildSpecialistChatEngine: %v", result.Err)
 	}
@@ -610,7 +620,9 @@ func TestBuildSpecialistChatEngineAttachesSessionEvolvingMemory(t *testing.T) {
 	}
 	app.invalidateSpecialistsCache(ctx, 7)
 
-	result := app.buildSpecialistChatEngine(ctx, buildSpecialistTestRequest("alpha", "", "sess-42", 7))
+	req := buildSpecialistTestRequest("alpha", "", "sess-42", 7)
+	req.MemorySettings = enabledChatMemoryRunSettings()
+	result := app.buildSpecialistChatEngine(ctx, req)
 	if result.Err != nil {
 		t.Fatalf("buildSpecialistChatEngine: %v", result.Err)
 	}
@@ -713,7 +725,9 @@ func TestBuildTeamChatEngineAttachesSessionEvolvingMemory(t *testing.T) {
 		t.Fatalf("upsert team: %v", err)
 	}
 
-	result := app.buildTeamChatEngine(ctx, buildTeamTestRequest("ops", "sess-team", 9))
+	req := buildTeamTestRequest("ops", "sess-team", 9)
+	req.MemorySettings = enabledChatMemoryRunSettings()
+	result := app.buildTeamChatEngine(ctx, req)
 	if result.Err != nil {
 		t.Fatalf("buildTeamChatEngine: %v", result.Err)
 	}

--- a/internal/agentd/chat_memory_settings.go
+++ b/internal/agentd/chat_memory_settings.go
@@ -13,9 +13,9 @@ type chatMemoryRunSettings struct {
 
 func defaultChatMemoryRunSettings() chatMemoryRunSettings {
 	return chatMemoryRunSettings{
-		MemoryEnabled:         true,
-		EvolvingMemoryEnabled: true,
-		BeliefMemoryEnabled:   true,
+		MemoryEnabled:         false,
+		EvolvingMemoryEnabled: false,
+		BeliefMemoryEnabled:   false,
 	}
 }
 

--- a/internal/agentd/engine_runtime.go
+++ b/internal/agentd/engine_runtime.go
@@ -143,7 +143,7 @@ func (a *app) configureUnifiedMemoryRuntime(eng *agent.Engine, em *memory.Evolvi
 		return
 	}
 	settings = normalizeChatMemoryRunSettings(settings)
-	if a.cfg == nil || !a.cfg.Memory.Enabled || !settings.MemoryEnabled {
+	if a.cfg == nil || !settings.MemoryEnabled {
 		eng.Memory = nil
 		eng.DisableMemory = true
 		return

--- a/internal/agentd/handlers_prompt_specialist_test.go
+++ b/internal/agentd/handlers_prompt_specialist_test.go
@@ -224,6 +224,7 @@ func TestPromptHandlerRoutesSpecialistBeforeDevMockFallback(t *testing.T) {
 				APIKey:  "test",
 				BaseURL: specialistServer.URL,
 				Model:   "spec-model",
+				API:     "completions",
 			},
 		},
 	}
@@ -301,6 +302,7 @@ func TestPromptHandlerSystemPromptOverridesDirectSpecialistPrompt(t *testing.T) 
 				APIKey:  "test",
 				BaseURL: specialistServer.URL,
 				Model:   "spec-model",
+				API:     "completions",
 			},
 		},
 	}
@@ -564,6 +566,7 @@ func newSpecialistTestApp(t *testing.T, baseURL string, specs []config.Specialis
 				APIKey:  "test",
 				BaseURL: baseURL,
 				Model:   "spec-model",
+				API:     "completions",
 			},
 		},
 	}

--- a/internal/agentd/playground_specialist_runner_test.go
+++ b/internal/agentd/playground_specialist_runner_test.go
@@ -73,12 +73,14 @@ func TestPlaygroundSpecialistRunnerUsesToolsAndIsolatedProjectContext(t *testing
 				APIKey:  "test",
 				BaseURL: specialistServer.URL,
 				Model:   "special-model",
+				API:     "completions",
 			},
 		},
 		OpenAI: config.OpenAIConfig{
 			APIKey:  "test",
 			BaseURL: specialistServer.URL,
 			Model:   "special-model",
+			API:     "completions",
 		},
 	}
 	specs := []config.SpecialistConfig{{
@@ -87,6 +89,7 @@ func TestPlaygroundSpecialistRunnerUsesToolsAndIsolatedProjectContext(t *testing
 		BaseURL:     specialistServer.URL,
 		APIKey:      "test",
 		Model:       "special-model",
+		API:         "completions",
 		EnableTools: true,
 		System:      "Use tools when useful.",
 	}}

--- a/internal/agentd/specialists_init.go
+++ b/internal/agentd/specialists_init.go
@@ -6,22 +6,25 @@ import (
 	"manifold/internal/persistence/databases"
 	"manifold/internal/specialists"
 
-	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/rs/zerolog/log"
 )
 
 func (a *app) initSpecialists(ctx context.Context) error {
-	var pg *pgxpool.Pool
-	if a.cfg.Databases.DefaultDSN != "" {
-		if p, err := databases.OpenPool(ctx, a.cfg.Databases.DefaultDSN); err == nil {
-			pg = p
-		}
+	specStore := a.mgr.Specialists
+	if specStore == nil {
+		specStore = databases.NewSpecialistsStore(nil)
 	}
-	specStore := databases.NewSpecialistsStore(pg)
-	_ = specStore.Init(ctx)
+	if err := specStore.Init(ctx); err != nil {
+		return err
+	}
 	a.specStore = specStore
-	teamStore := databases.NewSpecialistTeamsStore(pg)
-	_ = teamStore.Init(ctx)
+	teamStore := a.mgr.SpecialistTeams
+	if teamStore == nil {
+		teamStore = databases.NewSpecialistTeamsStore(nil)
+	}
+	if err := teamStore.Init(ctx); err != nil {
+		return err
+	}
 	a.teamStore = teamStore
 
 	if err := specialists.SeedStore(ctx, specStore, systemUserID, a.cfg.Specialists); err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -104,6 +104,15 @@ type Config struct {
 	Memory MemoryConfig `yaml:"memory" json:"memory"`
 	// MemoryConfigured is set when the YAML contains a top-level memory block.
 	MemoryConfigured bool `yaml:"-" json:"-"`
+	// EvolvingMemoryConfigured is set when the YAML contains the legacy
+	// top-level evolvingMemory block.
+	EvolvingMemoryConfigured bool `yaml:"-" json:"-"`
+	// BeliefMemoryConfigured is set when the YAML contains the legacy
+	// top-level beliefMemory block.
+	BeliefMemoryConfigured bool `yaml:"-" json:"-"`
+	// MagmaConfigured is set when the YAML contains the legacy top-level magma
+	// block.
+	MagmaConfigured bool `yaml:"-" json:"-"`
 	// ImageTool configures defaults for the describe_image tool.
 	ImageTool ImageToolConfig `yaml:"imageTool" json:"imageTool"`
 	// EvolvingMemory configures the Search-Synthesis-Evolve memory system.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -397,7 +397,7 @@ type OpenAIConfig struct {
 	SummaryModel   string `yaml:"summaryModel" json:"summaryModel"`
 	SummaryBaseURL string `yaml:"summaryBaseURL" json:"summaryBaseURL"`
 	// API selects which OpenAI-compatible API surface to use for chat: "completions" or "responses".
-	// Defaults to "completions" if empty or unrecognized.
+	// Defaults to "responses" if empty.
 	API string `yaml:"api" json:"api"`
 	// ExtraHeaders are added to every main agent HTTP request.
 	ExtraHeaders map[string]string `yaml:"extraHeaders" json:"extraHeaders"`

--- a/internal/config/example_test.go
+++ b/internal/config/example_test.go
@@ -46,3 +46,35 @@ func TestConfigYAMLExampleLoads(t *testing.T) {
 		t.Fatalf("expected no inline mcp.servers in config example, got %+v", cfg.MCP.Servers)
 	}
 }
+
+func TestConfigYAMLBasicLoads(t *testing.T) {
+	repoRoot := filepath.Join("..", "..")
+	data, err := os.ReadFile(filepath.Join(repoRoot, "config.yaml.basic"))
+	if err != nil {
+		t.Fatalf("read config.yaml.basic: %v", err)
+	}
+
+	tmpDir := t.TempDir()
+	home := filepath.Join(tmpDir, "home")
+	if err := os.WriteFile(filepath.Join(tmpDir, "config.yaml"), data, 0o644); err != nil {
+		t.Fatalf("write config.yaml: %v", err)
+	}
+	t.Chdir(tmpDir)
+
+	t.Setenv("HOME", home)
+	t.Setenv("OPENAI_API_KEY", "test-openai-key")
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("GOOGLE_LLM_API_KEY", "")
+	t.Setenv("GOOGLE_API_KEY", "")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() config.yaml.basic: %v", err)
+	}
+	if cfg.Workdir != filepath.Join(home, ".manifold", "projects") {
+		t.Fatalf("unexpected basic workdir: %q", cfg.Workdir)
+	}
+	if cfg.Memory.Enabled {
+		t.Fatal("expected basic config to leave global memory disabled")
+	}
+}

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -20,12 +20,14 @@ func Load() (Config, error) {
 	cfg := Config{}
 	cfg.Tokenization.FallbackToHeuristic = true
 
-	configPath, err := findRequiredFile("config.yaml", "config.yml")
+	configPath, found, err := findOptionalConfigFile("", "config.yaml", "config.yml")
 	if err != nil {
 		return Config{}, err
 	}
-	if err := loadMainConfig(configPath, &cfg); err != nil {
-		return Config{}, err
+	if found {
+		if err := loadMainConfig(configPath, &cfg); err != nil {
+			return Config{}, err
+		}
 	}
 	if err := loadExternalConfigs(&cfg); err != nil {
 		return Config{}, err
@@ -51,8 +53,11 @@ func loadMainConfig(path string, cfg *Config) error {
 	}
 
 	var aliases struct {
-		OutputTruncateByte int           `yaml:"outputTruncateByte"`
-		Memory             *MemoryConfig `yaml:"memory"`
+		OutputTruncateByte int                   `yaml:"outputTruncateByte"`
+		Memory             *MemoryConfig         `yaml:"memory"`
+		EvolvingMemory     *EvolvingMemoryConfig `yaml:"evolvingMemory"`
+		BeliefMemory       *BeliefMemoryConfig   `yaml:"beliefMemory"`
+		Magma              *MagmaConfig          `yaml:"magma"`
 	}
 	if err := yaml.Unmarshal(data, &aliases); err != nil {
 		return fmt.Errorf("%s: could not parse configuration aliases: %w", path, err)
@@ -61,6 +66,9 @@ func loadMainConfig(path string, cfg *Config) error {
 		cfg.OutputTruncateByte = aliases.OutputTruncateByte
 	}
 	cfg.MemoryConfigured = aliases.Memory != nil
+	cfg.EvolvingMemoryConfigured = aliases.EvolvingMemory != nil
+	cfg.BeliefMemoryConfigured = aliases.BeliefMemory != nil
+	cfg.MagmaConfigured = aliases.Magma != nil
 
 	return nil
 }
@@ -326,7 +334,14 @@ func validateConfigProviderCredentials(cfg *Config) error {
 
 func validateConfigWorkdir(cfg *Config) error {
 	if strings.TrimSpace(cfg.Workdir) == "" {
-		return errors.New("workdir is required")
+		workdir, err := defaultWorkdir()
+		if err != nil {
+			return err
+		}
+		cfg.Workdir = workdir
+		if err := os.MkdirAll(cfg.Workdir, 0o755); err != nil {
+			return fmt.Errorf("create default workdir: %w", err)
+		}
 	}
 	absWD, err := filepath.Abs(cfg.Workdir)
 	if err != nil {
@@ -341,6 +356,14 @@ func validateConfigWorkdir(cfg *Config) error {
 	}
 	cfg.Workdir = absWD
 	return nil
+}
+
+func defaultWorkdir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil || strings.TrimSpace(home) == "" {
+		return "", errors.New("workdir is required when HOME is unavailable")
+	}
+	return filepath.Join(home, ".manifold", "projects"), nil
 }
 
 func validateConfigExec(cfg *Config) error {

--- a/internal/config/loader_defaults.go
+++ b/internal/config/loader_defaults.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"os"
 	"reflect"
 	"strings"
 )
@@ -26,6 +27,7 @@ func applyUnifiedMemoryAliases(cfg *Config) {
 	}
 	applyUnifiedMemoryRetrievalDefaults(cfg)
 	if !cfg.MemoryConfigured {
+		applyDefaultMemorySubsystemCapabilities(cfg)
 		return
 	}
 	if !reflect.ValueOf(cfg.Memory.Evolving).IsZero() {
@@ -60,8 +62,6 @@ func syncUnifiedMemoryConfig(cfg *Config) {
 		cfg.EvolvingMemory.Enabled = cfg.Memory.Enabled
 		cfg.BeliefMemory.Enabled = cfg.Memory.Enabled
 		cfg.Magma.Enabled = cfg.Memory.Enabled
-	} else {
-		cfg.Memory.Enabled = cfg.EvolvingMemory.Enabled && cfg.BeliefMemory.Enabled && cfg.Magma.Enabled
 	}
 	cfg.Memory.Evolving = cfg.EvolvingMemory
 	cfg.Memory.Belief = cfg.BeliefMemory
@@ -76,6 +76,22 @@ func syncUnifiedMemoryConfig(cfg *Config) {
 	cfg.Memory.Magma.Consolidation.LLMClient = cfg.Magma.Consolidation.LLMClient
 }
 
+func applyDefaultMemorySubsystemCapabilities(cfg *Config) {
+	if !cfg.EvolvingMemoryConfigured {
+		cfg.EvolvingMemory.Enabled = true
+		cfg.EvolvingMemory.EnableRAG = true
+	}
+	if !cfg.BeliefMemoryConfigured {
+		cfg.BeliefMemory.Enabled = true
+		cfg.BeliefMemory.EnableDistillation = true
+		cfg.BeliefMemory.EnableRetrieval = true
+		cfg.BeliefMemory.EnableConstraintEnforcement = true
+	}
+	if !cfg.MagmaConfigured {
+		cfg.Magma.Enabled = true
+	}
+}
+
 func applyUnifiedMemoryRetrievalDefaults(cfg *Config) {
 	if cfg.Memory.Retrieval.MaxTokensPerPrompt <= 0 {
 		cfg.Memory.Retrieval.MaxTokensPerPrompt = 2200
@@ -87,19 +103,60 @@ func applyUnifiedMemoryRetrievalDefaults(cfg *Config) {
 }
 
 func applyLLMDefaults(cfg *Config) {
+	applyLLMEnvDefaults(cfg)
 	if cfg.LLMClient.Provider == "" {
-		cfg.LLMClient.Provider = "openai"
+		cfg.LLMClient.Provider = defaultLLMProvider(cfg.LLMClient)
 	}
 	if cfg.LLMClient.OpenAI.BaseURL == "" {
 		cfg.LLMClient.OpenAI.BaseURL = OpenAIAPIV1BaseURL
 	}
 	if cfg.LLMClient.OpenAI.Model == "" {
-		cfg.LLMClient.OpenAI.Model = "gpt-4o-mini"
+		cfg.LLMClient.OpenAI.Model = "gpt-5-mini"
 	}
 	if cfg.LLMClient.OpenAI.API == "" {
 		cfg.LLMClient.OpenAI.API = "completions"
 	}
+	if cfg.LLMClient.Anthropic.Model == "" {
+		cfg.LLMClient.Anthropic.Model = "claude-sonnet-4-6"
+	}
+	if cfg.LLMClient.Anthropic.BaseURL == "" {
+		cfg.LLMClient.Anthropic.BaseURL = "https://api.anthropic.com"
+	}
+	if cfg.LLMClient.Google.Model == "" {
+		cfg.LLMClient.Google.Model = "gemini-2.5-pro"
+	}
+	if cfg.LLMClient.Google.BaseURL == "" {
+		cfg.LLMClient.Google.BaseURL = "https://generativelanguage.googleapis.com/"
+	}
 	applySummaryDefaults(cfg)
+}
+
+func applyLLMEnvDefaults(cfg *Config) {
+	if strings.TrimSpace(cfg.LLMClient.OpenAI.APIKey) == "" {
+		cfg.LLMClient.OpenAI.APIKey = strings.TrimSpace(os.Getenv("OPENAI_API_KEY"))
+	}
+	if strings.TrimSpace(cfg.LLMClient.Anthropic.APIKey) == "" {
+		cfg.LLMClient.Anthropic.APIKey = strings.TrimSpace(os.Getenv("ANTHROPIC_API_KEY"))
+	}
+	if strings.TrimSpace(cfg.LLMClient.Google.APIKey) == "" {
+		cfg.LLMClient.Google.APIKey = firstNonEmpty(
+			strings.TrimSpace(os.Getenv("GOOGLE_LLM_API_KEY")),
+			strings.TrimSpace(os.Getenv("GOOGLE_API_KEY")),
+		)
+	}
+}
+
+func defaultLLMProvider(cfg LLMClientConfig) string {
+	switch {
+	case strings.TrimSpace(cfg.OpenAI.APIKey) != "":
+		return "openai"
+	case strings.TrimSpace(cfg.Anthropic.APIKey) != "":
+		return "anthropic"
+	case strings.TrimSpace(cfg.Google.APIKey) != "":
+		return "google"
+	default:
+		return "openai"
+	}
 }
 
 func applyObservabilityDefaults(cfg *Config) {
@@ -320,6 +377,12 @@ func applyEmbeddingAndRerankingDefaults(cfg *Config) {
 	if cfg.Embedding.Model == "" {
 		cfg.Embedding.Model = "text-embedding-3-small"
 	}
+	if strings.TrimSpace(cfg.Embedding.APIKey) == "" {
+		cfg.Embedding.APIKey = firstNonEmpty(
+			strings.TrimSpace(cfg.LLMClient.OpenAI.APIKey),
+			strings.TrimSpace(os.Getenv("OPENAI_API_KEY")),
+		)
+	}
 	if cfg.Embedding.APIHeader == "" {
 		cfg.Embedding.APIHeader = "Authorization"
 	}
@@ -348,6 +411,12 @@ func applyEmbeddingAndRerankingDefaults(cfg *Config) {
 	}
 	if cfg.Reranking.Timeout <= 0 {
 		cfg.Reranking.Timeout = 30
+	}
+	if cfg.ImageTool.BaseURL == "" {
+		cfg.ImageTool.BaseURL = OpenAIAPIV1BaseURL
+	}
+	if cfg.ImageTool.Model == "" {
+		cfg.ImageTool.Model = "gpt-5.4-mini"
 	}
 }
 

--- a/internal/config/loader_defaults.go
+++ b/internal/config/loader_defaults.go
@@ -114,7 +114,7 @@ func applyLLMDefaults(cfg *Config) {
 		cfg.LLMClient.OpenAI.Model = "gpt-5-mini"
 	}
 	if cfg.LLMClient.OpenAI.API == "" {
-		cfg.LLMClient.OpenAI.API = "completions"
+		cfg.LLMClient.OpenAI.API = "responses"
 	}
 	if cfg.LLMClient.Anthropic.Model == "" {
 		cfg.LLMClient.Anthropic.Model = "claude-sonnet-4-6"

--- a/internal/config/loader_memory_defaults.go
+++ b/internal/config/loader_memory_defaults.go
@@ -207,7 +207,7 @@ func applySummaryOpenAIDefaults(cfg *Config) {
 	if cfg.Summary.LLMClient.OpenAI.API == "" {
 		cfg.Summary.LLMClient.OpenAI.API = cfg.LLMClient.OpenAI.API
 		if cfg.Summary.LLMClient.OpenAI.API == "" {
-			cfg.Summary.LLMClient.OpenAI.API = "completions"
+			cfg.Summary.LLMClient.OpenAI.API = "responses"
 		}
 	}
 	if len(cfg.Summary.LLMClient.OpenAI.ExtraHeaders) == 0 && len(cfg.LLMClient.OpenAI.ExtraHeaders) > 0 {

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -543,7 +543,7 @@ llm_client:
 	if err != nil {
 		t.Fatalf("Load() error: %v", err)
 	}
-	if cfg.LLMClient.OpenAI.Model != "gpt-4o-mini" {
+	if cfg.LLMClient.OpenAI.Model != "gpt-5-mini" {
 		t.Fatalf("expected default model, got %q", cfg.LLMClient.OpenAI.Model)
 	}
 	if cfg.Exec.MaxCommandSeconds != 30 {
@@ -615,6 +615,79 @@ llm_client:
 	}
 	if cfg.Harness.Compact.KeepRecentSteps != 4 || !reflect.DeepEqual(cfg.Harness.Compact.PhaseThresholds, []float64{0.60, 0.75, 0.90}) {
 		t.Fatalf("unexpected default harness compact config: %+v", cfg.Harness.Compact)
+	}
+}
+
+func TestLoad_NoConfigFileUsesFirstRunDefaults(t *testing.T) {
+	tmpDir := t.TempDir()
+	home := filepath.Join(tmpDir, "home")
+	t.Chdir(tmpDir)
+	t.Setenv("HOME", home)
+	t.Setenv("OPENAI_API_KEY", "dummy-openai")
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("GOOGLE_LLM_API_KEY", "")
+	t.Setenv("GOOGLE_API_KEY", "")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	wantWorkdir := filepath.Join(home, ".manifold", "projects")
+	if cfg.Workdir != wantWorkdir {
+		t.Fatalf("expected default workdir %q, got %q", wantWorkdir, cfg.Workdir)
+	}
+	if info, err := os.Stat(wantWorkdir); err != nil || !info.IsDir() {
+		t.Fatalf("expected default workdir to be created, info=%v err=%v", info, err)
+	}
+	if cfg.LLMClient.Provider != "openai" || cfg.LLMClient.OpenAI.APIKey != "dummy-openai" {
+		t.Fatalf("unexpected llm defaults: %+v", cfg.LLMClient)
+	}
+	if cfg.Databases.Backend != "sqlite" {
+		t.Fatalf("expected sqlite default, got %q", cfg.Databases.Backend)
+	}
+	if cfg.Memory.Enabled {
+		t.Fatalf("expected global memory disabled by default")
+	}
+	if !cfg.EvolvingMemory.Enabled || !cfg.BeliefMemory.Enabled || !cfg.Magma.Enabled {
+		t.Fatalf("expected memory subsystems enabled, got evolving=%v belief=%v magma=%v", cfg.EvolvingMemory.Enabled, cfg.BeliefMemory.Enabled, cfg.Magma.Enabled)
+	}
+	if !cfg.EvolvingMemory.EnableRAG || !cfg.BeliefMemory.EnableDistillation || !cfg.BeliefMemory.EnableRetrieval || !cfg.BeliefMemory.EnableConstraintEnforcement {
+		t.Fatalf("unexpected memory subsystem defaults: evolving=%+v belief=%+v", cfg.EvolvingMemory, cfg.BeliefMemory)
+	}
+	if cfg.Embedding.BaseURL != OpenAIAPIBaseURL || cfg.Embedding.APIKey != "dummy-openai" {
+		t.Fatalf("unexpected embedding defaults: %+v", cfg.Embedding)
+	}
+	if cfg.ImageTool.BaseURL != OpenAIAPIV1BaseURL || cfg.ImageTool.Model != "gpt-5.4-mini" {
+		t.Fatalf("unexpected image tool defaults: %+v", cfg.ImageTool)
+	}
+	if cfg.Reranking.Enabled {
+		t.Fatalf("expected reranking disabled by default")
+	}
+}
+
+func TestLoad_MinimalConfigSelectsOnlyConfiguredProviderKey(t *testing.T) {
+	tmpDir := t.TempDir()
+	home := filepath.Join(tmpDir, "home")
+	t.Chdir(tmpDir)
+	t.Setenv("HOME", home)
+	t.Setenv("OPENAI_API_KEY", "")
+	t.Setenv("ANTHROPIC_API_KEY", "dummy-anthropic")
+	t.Setenv("GOOGLE_LLM_API_KEY", "")
+	t.Setenv("GOOGLE_API_KEY", "")
+
+	if err := os.WriteFile(filepath.Join(tmpDir, "config.yaml"), []byte(``), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	if cfg.LLMClient.Provider != "anthropic" {
+		t.Fatalf("expected anthropic provider from env-only config, got %q", cfg.LLMClient.Provider)
+	}
+	if cfg.LLMClient.Anthropic.APIKey != "dummy-anthropic" {
+		t.Fatalf("expected anthropic api key from env, got %q", cfg.LLMClient.Anthropic.APIKey)
 	}
 }
 

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -546,6 +546,9 @@ llm_client:
 	if cfg.LLMClient.OpenAI.Model != "gpt-5-mini" {
 		t.Fatalf("expected default model, got %q", cfg.LLMClient.OpenAI.Model)
 	}
+	if cfg.LLMClient.OpenAI.API != "responses" {
+		t.Fatalf("expected default OpenAI api responses, got %q", cfg.LLMClient.OpenAI.API)
+	}
 	if cfg.Exec.MaxCommandSeconds != 30 {
 		t.Fatalf("expected default command timeout, got %d", cfg.Exec.MaxCommandSeconds)
 	}
@@ -641,6 +644,9 @@ func TestLoad_NoConfigFileUsesFirstRunDefaults(t *testing.T) {
 	}
 	if cfg.LLMClient.Provider != "openai" || cfg.LLMClient.OpenAI.APIKey != "dummy-openai" {
 		t.Fatalf("unexpected llm defaults: %+v", cfg.LLMClient)
+	}
+	if cfg.LLMClient.OpenAI.API != "responses" {
+		t.Fatalf("expected default OpenAI api responses, got %q", cfg.LLMClient.OpenAI.API)
 	}
 	if cfg.Databases.Backend != "sqlite" {
 		t.Fatalf("expected sqlite default, got %q", cfg.Databases.Backend)

--- a/internal/llm/openai/client.go
+++ b/internal/llm/openai/client.go
@@ -83,7 +83,9 @@ func New(c config.OpenAIConfig, httpClient *http.Client) *Client {
 			isSelfHost: true,
 		}
 
-		httpClient.Transport = wrappedTransport
+		clientCopy := *httpClient
+		clientCopy.Transport = wrappedTransport
+		httpClient = &clientCopy
 	}
 
 	opts := []option.RequestOption{option.WithAPIKey(c.APIKey)}

--- a/internal/llm/openai/client.go
+++ b/internal/llm/openai/client.go
@@ -26,7 +26,7 @@ type Client struct {
 	logPayloads              bool
 	baseURL                  string
 	httpClient               *http.Client
-	api                      string // "completions" (default) or "responses"
+	api                      string // "responses" (default) or "completions"
 	apiKey                   string // Stored for raw HTTP requests (e.g., Gemini)
 	inputTokensUnsupported   atomic.Bool
 	applyTemplateUnsupported atomic.Bool
@@ -94,7 +94,7 @@ func New(c config.OpenAIConfig, httpClient *http.Client) *Client {
 
 	api := strings.ToLower(strings.TrimSpace(c.API))
 	if api == "" {
-		api = "completions"
+		api = "responses"
 	}
 	policy := defaultResponsesContextPolicy(c.Model)
 	policy.applyOverrides(llm.NormalizeExtraParams(c.ExtraParams), c.Model)

--- a/internal/llm/openai/client_test.go
+++ b/internal/llm/openai/client_test.go
@@ -44,6 +44,15 @@ func openAICloudTestClient(serverURL string) (*http.Client, error) {
 	return &http.Client{Transport: rewriteTransport{target: target, base: transport}}, nil
 }
 
+func TestClientDefaultsToResponsesAPI(t *testing.T) {
+	t.Parallel()
+
+	cli := New(config.OpenAIConfig{APIKey: "test", BaseURL: config.OpenAIAPIV1BaseURL, Model: "m"}, nil)
+	if cli.api != "responses" {
+		t.Fatalf("expected default api responses, got %q", cli.api)
+	}
+}
+
 func TestChatWithOptions_ServerReturnsChoice(t *testing.T) {
 	// Start a test server that mimics minimal OpenAI Chat Completion response.
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -54,7 +63,7 @@ func TestChatWithOptions_ServerReturnsChoice(t *testing.T) {
 	srv := httptest.NewServer(h)
 	defer srv.Close()
 
-	c := config.OpenAIConfig{APIKey: "test", BaseURL: srv.URL, Model: "m"}
+	c := config.OpenAIConfig{APIKey: "test", BaseURL: srv.URL, Model: "m", API: "completions"}
 	cli := New(c, srv.Client())
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
@@ -88,7 +97,7 @@ func TestSelfHostedChatUsesReturnedUsageWithoutTokenizeFallback(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	cli := New(config.OpenAIConfig{APIKey: "test", BaseURL: srv.URL, Model: "m"}, srv.Client())
+	cli := New(config.OpenAIConfig{APIKey: "test", BaseURL: srv.URL, Model: "m", API: "completions"}, srv.Client())
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
@@ -123,7 +132,7 @@ func TestChatWithOptions_AppendsWebSearchOptions(t *testing.T) {
 	if err != nil {
 		t.Fatalf("test client: %v", err)
 	}
-	c := config.OpenAIConfig{APIKey: "test", BaseURL: "https://api.openai.com/v1", Model: "gpt-5-search-api"}
+	c := config.OpenAIConfig{APIKey: "test", BaseURL: "https://api.openai.com/v1", Model: "gpt-5-search-api", API: "completions"}
 	cli := New(c, httpClient)
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
@@ -164,7 +173,7 @@ func TestChatWithOptionsNilToolsOmitsNativeWebSearch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("test client: %v", err)
 	}
-	c := config.OpenAIConfig{APIKey: "test", BaseURL: "https://api.openai.com/v1", Model: "gpt-5-search-api"}
+	c := config.OpenAIConfig{APIKey: "test", BaseURL: "https://api.openai.com/v1", Model: "gpt-5-search-api", API: "completions"}
 	cli := New(c, httpClient)
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
@@ -544,6 +553,7 @@ func TestSelfHostedSSEHeaderInjection(t *testing.T) {
 		APIKey:  "test",
 		BaseURL: srv.URL, // This should trigger SSE header injection
 		Model:   "test-model",
+		API:     "completions",
 	}
 	cli := New(c, httpClient)
 
@@ -595,7 +605,7 @@ func TestSelfHostedSSEFallbackUsesFinalUsageChunkForMetrics(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	cli := New(config.OpenAIConfig{APIKey: "test", BaseURL: srv.URL, Model: model}, srv.Client())
+	cli := New(config.OpenAIConfig{APIKey: "test", BaseURL: srv.URL, Model: model, API: "completions"}, srv.Client())
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
@@ -682,7 +692,7 @@ func TestSelfHostedChatStripsTaggedThoughtContent(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	cli := New(config.OpenAIConfig{APIKey: "test", BaseURL: srv.URL, Model: "m"}, srv.Client())
+	cli := New(config.OpenAIConfig{APIKey: "test", BaseURL: srv.URL, Model: "m", API: "completions"}, srv.Client())
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
@@ -722,7 +732,7 @@ func TestSelfHostedChatStreamParsesTaggedThoughtContent(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	cli := New(config.OpenAIConfig{APIKey: "test", BaseURL: srv.URL, Model: "m"}, srv.Client())
+	cli := New(config.OpenAIConfig{APIKey: "test", BaseURL: srv.URL, Model: "m", API: "completions"}, srv.Client())
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
@@ -763,7 +773,7 @@ func TestSelfHostedChatStripsThinkBlockContent(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	cli := New(config.OpenAIConfig{APIKey: "test", BaseURL: srv.URL, Model: "m"}, srv.Client())
+	cli := New(config.OpenAIConfig{APIKey: "test", BaseURL: srv.URL, Model: "m", API: "completions"}, srv.Client())
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
@@ -800,7 +810,7 @@ func TestSelfHostedChatStreamParsesThinkBlocks(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	cli := New(config.OpenAIConfig{APIKey: "test", BaseURL: srv.URL, Model: "m"}, srv.Client())
+	cli := New(config.OpenAIConfig{APIKey: "test", BaseURL: srv.URL, Model: "m", API: "completions"}, srv.Client())
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
@@ -843,7 +853,7 @@ func TestSelfHostedChatStreamUsesMessageReasoningContent(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	cli := New(config.OpenAIConfig{APIKey: "test", BaseURL: srv.URL, Model: "m"}, srv.Client())
+	cli := New(config.OpenAIConfig{APIKey: "test", BaseURL: srv.URL, Model: "m", API: "completions"}, srv.Client())
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
@@ -883,7 +893,7 @@ func TestSelfHostedChatStreamAccumulatesReasoningContentTokens(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	cli := New(config.OpenAIConfig{APIKey: "test", BaseURL: srv.URL, Model: "m"}, srv.Client())
+	cli := New(config.OpenAIConfig{APIKey: "test", BaseURL: srv.URL, Model: "m", API: "completions"}, srv.Client())
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 

--- a/internal/llm/openai/client_test.go
+++ b/internal/llm/openai/client_test.go
@@ -53,6 +53,31 @@ func TestClientDefaultsToResponsesAPI(t *testing.T) {
 	}
 }
 
+func TestNewDoesNotMutateProvidedHTTPClientTransport(t *testing.T) {
+	t.Parallel()
+
+	transport := http.DefaultTransport
+	client := &http.Client{
+		Transport: transport,
+		Timeout:   time.Second,
+	}
+
+	cli := New(config.OpenAIConfig{APIKey: "test", BaseURL: "http://localhost:8000", Model: "m"}, client)
+
+	if client.Transport != transport {
+		t.Fatalf("expected original client transport to be unchanged")
+	}
+	if cli.httpClient == client {
+		t.Fatalf("expected self-hosted wrapper to use a client copy")
+	}
+	if cli.httpClient.Timeout != client.Timeout {
+		t.Fatalf("expected copied client to preserve timeout")
+	}
+	if _, ok := cli.httpClient.Transport.(*sseTransportWrapper); !ok {
+		t.Fatalf("expected copied client to use SSE transport wrapper, got %T", cli.httpClient.Transport)
+	}
+}
+
 func TestChatWithOptions_ServerReturnsChoice(t *testing.T) {
 	// Start a test server that mimics minimal OpenAI Chat Completion response.
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/persistence/databases/chat_store_memory.go
+++ b/internal/persistence/databases/chat_store_memory.go
@@ -37,9 +37,9 @@ func newChatSession(id string, userID *int64, name string, kind string, now time
 		UserID:                copyUserID(userID),
 		CreatedAt:             now,
 		UpdatedAt:             now,
-		MemoryEnabled:         true,
-		EvolvingMemoryEnabled: true,
-		BeliefMemoryEnabled:   true,
+		MemoryEnabled:         false,
+		EvolvingMemoryEnabled: false,
+		BeliefMemoryEnabled:   false,
 	}
 }
 

--- a/internal/persistence/databases/chat_store_memory_test.go
+++ b/internal/persistence/databases/chat_store_memory_test.go
@@ -23,8 +23,8 @@ func TestMemChatStoreLifecycle(t *testing.T) {
 	if sess.ID != "session-1" {
 		t.Fatalf("unexpected session id: %s", sess.ID)
 	}
-	if !sess.MemoryEnabled || !sess.EvolvingMemoryEnabled || !sess.BeliefMemoryEnabled {
-		t.Fatalf("new sessions should default unified memory on, got memory=%v evolving=%v belief=%v", sess.MemoryEnabled, sess.EvolvingMemoryEnabled, sess.BeliefMemoryEnabled)
+	if sess.MemoryEnabled || sess.EvolvingMemoryEnabled || sess.BeliefMemoryEnabled {
+		t.Fatalf("new sessions should default unified memory off, got memory=%v evolving=%v belief=%v", sess.MemoryEnabled, sess.EvolvingMemoryEnabled, sess.BeliefMemoryEnabled)
 	}
 
 	if err := store.AppendMessages(ctx, nil, "session-1", nil, "", ""); err != nil {

--- a/internal/persistence/databases/chat_store_postgres.go
+++ b/internal/persistence/databases/chat_store_postgres.go
@@ -41,9 +41,9 @@ CREATE TABLE IF NOT EXISTS chat_sessions (
     summary TEXT NOT NULL DEFAULT '',
     summarized_count INTEGER NOT NULL DEFAULT 0,
     project_id TEXT NOT NULL DEFAULT '',
-    memory_enabled BOOLEAN NOT NULL DEFAULT TRUE,
-    evolving_memory_enabled BOOLEAN NOT NULL DEFAULT TRUE,
-    belief_memory_enabled BOOLEAN NOT NULL DEFAULT TRUE
+    memory_enabled BOOLEAN NOT NULL DEFAULT FALSE,
+    evolving_memory_enabled BOOLEAN NOT NULL DEFAULT FALSE,
+    belief_memory_enabled BOOLEAN NOT NULL DEFAULT FALSE
 );
 
 CREATE TABLE IF NOT EXISTS chat_messages (
@@ -72,25 +72,25 @@ ALTER TABLE chat_sessions
     ADD COLUMN IF NOT EXISTS project_id TEXT NOT NULL DEFAULT '';
 
 ALTER TABLE chat_sessions
-    ADD COLUMN IF NOT EXISTS memory_enabled BOOLEAN NOT NULL DEFAULT TRUE;
+    ADD COLUMN IF NOT EXISTS memory_enabled BOOLEAN NOT NULL DEFAULT FALSE;
 
 ALTER TABLE chat_sessions
-    ADD COLUMN IF NOT EXISTS evolving_memory_enabled BOOLEAN NOT NULL DEFAULT TRUE;
+    ADD COLUMN IF NOT EXISTS evolving_memory_enabled BOOLEAN NOT NULL DEFAULT FALSE;
 
 ALTER TABLE chat_sessions
-    ADD COLUMN IF NOT EXISTS belief_memory_enabled BOOLEAN NOT NULL DEFAULT TRUE;
+    ADD COLUMN IF NOT EXISTS belief_memory_enabled BOOLEAN NOT NULL DEFAULT FALSE;
 
 ALTER TABLE chat_sessions
-    ALTER COLUMN memory_enabled SET DEFAULT TRUE;
+    ALTER COLUMN memory_enabled SET DEFAULT FALSE;
 
 ALTER TABLE chat_sessions
-    ALTER COLUMN evolving_memory_enabled SET DEFAULT TRUE;
+    ALTER COLUMN evolving_memory_enabled SET DEFAULT FALSE;
 
 UPDATE chat_sessions
 SET memory_enabled = evolving_memory_enabled AND belief_memory_enabled;
 
 ALTER TABLE chat_sessions
-    ALTER COLUMN belief_memory_enabled SET DEFAULT TRUE;
+    ALTER COLUMN belief_memory_enabled SET DEFAULT FALSE;
 
 UPDATE chat_sessions
 SET evolving_memory_enabled = memory_enabled,

--- a/internal/persistence/databases/chat_store_sqlite.go
+++ b/internal/persistence/databases/chat_store_sqlite.go
@@ -46,9 +46,9 @@ CREATE TABLE IF NOT EXISTS chat_sessions (
 	summary TEXT NOT NULL DEFAULT '',
 	summarized_count INTEGER NOT NULL DEFAULT 0,
 	project_id TEXT NOT NULL DEFAULT '',
-	memory_enabled BOOLEAN NOT NULL DEFAULT TRUE,
-	evolving_memory_enabled BOOLEAN NOT NULL DEFAULT TRUE,
-	belief_memory_enabled BOOLEAN NOT NULL DEFAULT TRUE
+	memory_enabled BOOLEAN NOT NULL DEFAULT FALSE,
+	evolving_memory_enabled BOOLEAN NOT NULL DEFAULT FALSE,
+	belief_memory_enabled BOOLEAN NOT NULL DEFAULT FALSE
 );
 CREATE TABLE IF NOT EXISTS chat_messages (
 	id TEXT PRIMARY KEY,

--- a/internal/persistence/databases/databases_test.go
+++ b/internal/persistence/databases/databases_test.go
@@ -8,8 +8,10 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"manifold/internal/config"
+	"manifold/internal/persistence"
 	sqlitep "manifold/internal/persistence/sqlite"
 )
 
@@ -345,6 +347,133 @@ func TestFactory_DefaultsAndNone(t *testing.T) {
 	_ = mgr.Vector.Upsert(ctx, "x", []float32{1}, nil)
 	_, _ = mgr.Vector.SimilaritySearch(ctx, []float32{1}, 1, nil)
 	_ = mgr.Graph.UpsertNode(ctx, "n", nil, nil)
+}
+
+func TestFactory_DefaultSQLitePersistsSpecialistsAcrossManagers(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "manifold.db")
+	cfg := config.DBConfig{SQLite: config.SQLiteConfig{Path: dbPath}}
+	mgr, err := NewManager(ctx, cfg)
+	if err != nil {
+		t.Fatalf("NewManager error: %v", err)
+	}
+	if mgr.Specialists == nil || mgr.SpecialistTeams == nil {
+		t.Fatalf("expected sqlite specialist stores")
+	}
+	_, err = mgr.Specialists.Upsert(ctx, 0, persistence.Specialist{
+		Name:        "writer",
+		Provider:    "openai",
+		Model:       "gpt-5-mini",
+		Description: "durable specialist",
+	})
+	if err != nil {
+		t.Fatalf("upsert specialist: %v", err)
+	}
+	mgr.Close()
+
+	restarted, err := NewManager(ctx, cfg)
+	if err != nil {
+		t.Fatalf("NewManager after restart error: %v", err)
+	}
+	defer restarted.Close()
+	got, ok, err := restarted.Specialists.GetByName(ctx, 0, "writer")
+	if err != nil {
+		t.Fatalf("get specialist after restart: %v", err)
+	}
+	if !ok || got.Description != "durable specialist" || got.Model != "gpt-5-mini" {
+		t.Fatalf("specialist did not persist across manager restart: ok=%v got=%+v", ok, got)
+	}
+}
+
+func TestFactory_DefaultSQLitePersistsTeamsAcrossManagers(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "manifold.db")
+	cfg := config.DBConfig{SQLite: config.SQLiteConfig{Path: dbPath}}
+	mgr, err := NewManager(ctx, cfg)
+	if err != nil {
+		t.Fatalf("NewManager error: %v", err)
+	}
+	_, err = mgr.Specialists.Upsert(ctx, 0, persistence.Specialist{
+		Name:     "lead",
+		Provider: "openai",
+		Model:    "gpt-5-mini",
+	})
+	if err != nil {
+		t.Fatalf("upsert specialist: %v", err)
+	}
+	_, err = mgr.SpecialistTeams.Upsert(ctx, 0, persistence.SpecialistTeam{
+		Name:             "ops",
+		Description:      "durable team",
+		OrchestratorName: "lead",
+		Members:          []string{"lead"},
+	})
+	if err != nil {
+		t.Fatalf("upsert team: %v", err)
+	}
+	mgr.Close()
+
+	restarted, err := NewManager(ctx, cfg)
+	if err != nil {
+		t.Fatalf("NewManager after restart error: %v", err)
+	}
+	defer restarted.Close()
+	got, ok, err := restarted.SpecialistTeams.GetByName(ctx, 0, "ops")
+	if err != nil {
+		t.Fatalf("get team after restart: %v", err)
+	}
+	if !ok || got.Description != "durable team" || got.OrchestratorName != "lead" {
+		t.Fatalf("team did not persist across manager restart: ok=%v got=%+v", ok, got)
+	}
+	if len(got.Members) != 1 || got.Members[0] != "lead" {
+		t.Fatalf("team membership did not persist across manager restart: %+v", got.Members)
+	}
+	listCtx, cancel := context.WithTimeout(ctx, time.Second)
+	defer cancel()
+	teams, err := restarted.SpecialistTeams.List(listCtx, 0)
+	if err != nil {
+		t.Fatalf("list teams after restart: %v", err)
+	}
+	if len(teams) != 1 || teams[0].Name != "ops" || len(teams[0].Members) != 1 || teams[0].Members[0] != "lead" {
+		t.Fatalf("unexpected teams after restart: %+v", teams)
+	}
+}
+
+func TestSQLiteTeamStoreListDoesNotDeadlockWithSingleConnection(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	mgr, err := NewManager(ctx, config.DBConfig{
+		SQLite: config.SQLiteConfig{
+			Path:         filepath.Join(t.TempDir(), "manifold.db"),
+			MaxOpenConns: 1,
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewManager error: %v", err)
+	}
+	defer mgr.Close()
+	_, err = mgr.SpecialistTeams.Upsert(ctx, 0, persistence.SpecialistTeam{
+		Name:             "ops",
+		OrchestratorName: "lead",
+		Members:          []string{"lead"},
+	})
+	if err != nil {
+		t.Fatalf("upsert team: %v", err)
+	}
+
+	listCtx, cancel := context.WithTimeout(ctx, time.Second)
+	defer cancel()
+	teams, err := mgr.SpecialistTeams.List(listCtx, 0)
+	if err != nil {
+		t.Fatalf("list teams: %v", err)
+	}
+	if len(teams) != 1 || teams[0].Name != "ops" || len(teams[0].Members) != 1 || teams[0].Members[0] != "lead" {
+		t.Fatalf("unexpected teams: %+v", teams)
+	}
 }
 
 func TestFactory_RejectsPostgresWithoutDSN(t *testing.T) {

--- a/internal/persistence/databases/factory.go
+++ b/internal/persistence/databases/factory.go
@@ -391,15 +391,25 @@ func initializePlaygroundDefaultStore(ctx context.Context, m *Manager, cfg confi
 
 func initializeConfigDefaultStores(ctx context.Context, m *Manager, cfg config.DBConfig, defaultBackend string) error {
 	if defaultBackend == "sqlite" {
+		m.Specialists = NewSQLiteSpecialistsStore(m.SQLite)
+		m.SpecialistTeams = NewSQLiteSpecialistTeamsStore(m.SQLite)
 		m.MCP = NewSQLiteMCPStore(m.SQLite)
 		m.Projects = NewSQLiteProjectsStore(m.SQLite)
 		m.UserPreferences = NewSQLiteUserPreferencesStore(m.SQLite)
 		m.CommandPolicy = NewSQLiteCommandPolicyStore(m.SQLite)
 	} else {
+		m.Specialists = newStoreWithOptionalPool(ctx, cfg.DefaultDSN, NewSpecialistsStore)
+		m.SpecialistTeams = newStoreWithOptionalPool(ctx, cfg.DefaultDSN, NewSpecialistTeamsStore)
 		m.MCP = newStoreWithOptionalPool(ctx, cfg.DefaultDSN, NewMCPStore)
 		m.Projects = newStoreWithOptionalPool(ctx, cfg.DefaultDSN, NewPostgresProjectsStore)
 		m.UserPreferences = newStoreWithOptionalPool(ctx, cfg.DefaultDSN, NewUserPreferencesStore)
 		m.CommandPolicy = newStoreWithOptionalPool(ctx, cfg.DefaultDSN, NewCommandPolicyStore)
+	}
+	if err := initStore(ctx, "specialists store", m.Specialists); err != nil {
+		return err
+	}
+	if err := initStore(ctx, "specialist teams store", m.SpecialistTeams); err != nil {
+		return err
 	}
 	if err := initStore(ctx, "mcp store", m.MCP); err != nil {
 		return err

--- a/internal/persistence/databases/interfaces.go
+++ b/internal/persistence/databases/interfaces.go
@@ -68,6 +68,8 @@ type Manager struct {
 	Graph              GraphDB
 	Chat               persistence.ChatStore
 	SpecialistActivity persistence.SpecialistActivityStore
+	Specialists        persistence.SpecialistsStore
+	SpecialistTeams    persistence.SpecialistTeamsStore
 	EvolvingMemory     memory.EvolvingMemoryStore
 	Playground         *PlaygroundStore
 	FlowV2             persistence.FlowV2WorkflowStore
@@ -90,6 +92,8 @@ func (m Manager) Close() {
 	closeIfPossible(m.Graph)
 	closeIfPossible(m.Chat)
 	closeIfPossible(m.SpecialistActivity)
+	closeIfPossible(m.Specialists)
+	closeIfPossible(m.SpecialistTeams)
 	closeIfPossible(m.EvolvingMemory)
 	closeIfPossible(m.Playground)
 	closeIfPossible(m.FlowV2)

--- a/internal/persistence/databases/specialist_teams_store.go
+++ b/internal/persistence/databases/specialist_teams_store.go
@@ -2,9 +2,11 @@ package databases
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"strings"
+	"sync"
 	"time"
 
 	"manifold/internal/persistence"
@@ -19,6 +21,294 @@ func NewSpecialistTeamsStore(pool *pgxpool.Pool) persistence.SpecialistTeamsStor
 		return &memTeamStore{teams: map[int64]map[string]persistence.SpecialistTeam{}, memberships: map[int64]map[string]map[string]struct{}{}}
 	}
 	return &pgTeamStore{pool: pool}
+}
+
+type sqliteTeamStore struct {
+	db       *sql.DB
+	initOnce sync.Once
+	initErr  error
+}
+
+func NewSQLiteSpecialistTeamsStore(db *sql.DB) persistence.SpecialistTeamsStore {
+	return &sqliteTeamStore{db: db}
+}
+
+func (s *sqliteTeamStore) Init(ctx context.Context) error {
+	if s.db == nil {
+		return errors.New("sqlite specialist teams store requires db")
+	}
+	s.initOnce.Do(func() {
+		_, s.initErr = s.db.ExecContext(ctx, `
+CREATE TABLE IF NOT EXISTS specialist_groups (
+	id INTEGER PRIMARY KEY AUTOINCREMENT,
+	user_id INTEGER NOT NULL DEFAULT 0,
+	name TEXT NOT NULL,
+	description TEXT NOT NULL DEFAULT '',
+	orchestrator_name TEXT NOT NULL DEFAULT '',
+	orchestrator TEXT NOT NULL DEFAULT '{}' CHECK (json_valid(orchestrator)),
+	created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	UNIQUE(user_id, name)
+);
+CREATE TABLE IF NOT EXISTS specialist_group_memberships (
+	user_id INTEGER NOT NULL DEFAULT 0,
+	group_id INTEGER NOT NULL REFERENCES specialist_groups(id) ON DELETE CASCADE,
+	specialist_name TEXT NOT NULL,
+	PRIMARY KEY(user_id, group_id, specialist_name)
+);
+CREATE INDEX IF NOT EXISTS specialist_groups_user_name_idx ON specialist_groups(user_id, name);
+`)
+	})
+	return s.initErr
+}
+
+func (s *sqliteTeamStore) List(ctx context.Context, userID int64) ([]persistence.SpecialistTeam, error) {
+	if err := s.Init(ctx); err != nil {
+		return nil, err
+	}
+	rows, err := s.db.QueryContext(ctx, `
+SELECT id, user_id, name, description, orchestrator_name, orchestrator, created_at, updated_at
+FROM specialist_groups
+WHERE user_id = ?
+ORDER BY LOWER(name)`, userID)
+	if err != nil {
+		return nil, err
+	}
+	out := []persistence.SpecialistTeam{}
+	for rows.Next() {
+		team, err := scanSQLiteSpecialistTeam(rows)
+		if err != nil {
+			_ = rows.Close()
+			return nil, err
+		}
+		out = append(out, team)
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return nil, err
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	membersByID, err := s.membersByTeamID(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+	for i := range out {
+		out[i].Members = membersByID[out[i].ID]
+		if out[i].Members == nil {
+			out[i].Members = []string{}
+		}
+	}
+	return out, nil
+}
+
+func (s *sqliteTeamStore) GetByName(ctx context.Context, userID int64, name string) (persistence.SpecialistTeam, bool, error) {
+	if err := s.Init(ctx); err != nil {
+		return persistence.SpecialistTeam{}, false, err
+	}
+	row := s.db.QueryRowContext(ctx, `
+SELECT id, user_id, name, description, orchestrator_name, orchestrator, created_at, updated_at
+FROM specialist_groups
+WHERE user_id = ? AND LOWER(name) = LOWER(?)`, userID, name)
+	team, err := scanSQLiteSpecialistTeam(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return persistence.SpecialistTeam{}, false, nil
+	}
+	if err != nil {
+		return persistence.SpecialistTeam{}, false, err
+	}
+	team.Members = s.membersForTeam(ctx, userID, team.ID)
+	return team, true, nil
+}
+
+func (s *sqliteTeamStore) Upsert(ctx context.Context, teamUserID int64, team persistence.SpecialistTeam) (persistence.SpecialistTeam, error) {
+	if strings.TrimSpace(team.Name) == "" {
+		return persistence.SpecialistTeam{}, errors.New("name required")
+	}
+	if err := s.Init(ctx); err != nil {
+		return persistence.SpecialistTeam{}, err
+	}
+	orch, _ := json.Marshal(team.Orchestrator)
+	now := time.Now().UTC()
+	row := s.db.QueryRowContext(ctx, `
+INSERT INTO specialist_groups(user_id, name, description, orchestrator_name, orchestrator, created_at, updated_at)
+VALUES(?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT(user_id, name) DO UPDATE SET
+	description = excluded.description,
+	orchestrator_name = excluded.orchestrator_name,
+	orchestrator = excluded.orchestrator,
+	updated_at = excluded.updated_at
+RETURNING id, created_at, updated_at`, teamUserID, team.Name, team.Description, team.OrchestratorName, string(orch), now, now)
+	if err := row.Scan(&team.ID, &team.CreatedAt, &team.UpdatedAt); err != nil {
+		return persistence.SpecialistTeam{}, err
+	}
+	team.UserID = teamUserID
+	if team.Members != nil {
+		if err := s.replaceMembers(ctx, teamUserID, team.ID, team.Members); err != nil {
+			return persistence.SpecialistTeam{}, err
+		}
+	}
+	team.Members = s.membersForTeam(ctx, teamUserID, team.ID)
+	return team, nil
+}
+
+func (s *sqliteTeamStore) Delete(ctx context.Context, userID int64, name string) error {
+	if err := s.Init(ctx); err != nil {
+		return err
+	}
+	_, err := s.db.ExecContext(ctx, `DELETE FROM specialist_groups WHERE user_id = ? AND LOWER(name) = LOWER(?)`, userID, name)
+	return err
+}
+
+func (s *sqliteTeamStore) AddMember(ctx context.Context, userID int64, teamName string, specialistName string) error {
+	if strings.TrimSpace(teamName) == "" || strings.TrimSpace(specialistName) == "" {
+		return errors.New("team and specialist required")
+	}
+	if err := s.Init(ctx); err != nil {
+		return err
+	}
+	teamID, ok, err := s.teamID(ctx, userID, teamName)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return persistence.ErrNotFound
+	}
+	_, err = s.db.ExecContext(ctx, `
+INSERT INTO specialist_group_memberships(user_id, group_id, specialist_name)
+VALUES(?, ?, ?)
+ON CONFLICT DO NOTHING`, userID, teamID, specialistName)
+	return err
+}
+
+func (s *sqliteTeamStore) RemoveMember(ctx context.Context, userID int64, teamName string, specialistName string) error {
+	if err := s.Init(ctx); err != nil {
+		return err
+	}
+	teamID, ok, err := s.teamID(ctx, userID, teamName)
+	if err != nil || !ok {
+		return err
+	}
+	_, err = s.db.ExecContext(ctx, `DELETE FROM specialist_group_memberships WHERE user_id = ? AND group_id = ? AND specialist_name = ?`, userID, teamID, specialistName)
+	return err
+}
+
+func (s *sqliteTeamStore) ListMemberships(ctx context.Context, userID int64) (map[string][]string, error) {
+	if err := s.Init(ctx); err != nil {
+		return nil, err
+	}
+	rows, err := s.db.QueryContext(ctx, `
+SELECT m.specialist_name, g.name
+FROM specialist_group_memberships m
+JOIN specialist_groups g ON g.id = m.group_id AND g.user_id = m.user_id
+WHERE m.user_id = ?`, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := map[string][]string{}
+	for rows.Next() {
+		var specialistName, teamName string
+		if err := rows.Scan(&specialistName, &teamName); err != nil {
+			return nil, err
+		}
+		out[specialistName] = append(out[specialistName], teamName)
+	}
+	for specialistName := range out {
+		sortStrings(out[specialistName])
+	}
+	return out, rows.Err()
+}
+
+func (s *sqliteTeamStore) replaceMembers(ctx context.Context, userID int64, teamID int64, members []string) error {
+	if _, err := s.db.ExecContext(ctx, `DELETE FROM specialist_group_memberships WHERE user_id = ? AND group_id = ?`, userID, teamID); err != nil {
+		return err
+	}
+	for _, member := range members {
+		member = strings.TrimSpace(member)
+		if member == "" {
+			continue
+		}
+		if _, err := s.db.ExecContext(ctx, `
+INSERT INTO specialist_group_memberships(user_id, group_id, specialist_name)
+VALUES(?, ?, ?)
+ON CONFLICT DO NOTHING`, userID, teamID, member); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *sqliteTeamStore) teamID(ctx context.Context, userID int64, name string) (int64, bool, error) {
+	var id int64
+	err := s.db.QueryRowContext(ctx, `SELECT id FROM specialist_groups WHERE user_id = ? AND LOWER(name) = LOWER(?)`, userID, name).Scan(&id)
+	if errors.Is(err, sql.ErrNoRows) {
+		return 0, false, nil
+	}
+	if err != nil {
+		return 0, false, err
+	}
+	return id, true, nil
+}
+
+func (s *sqliteTeamStore) membersForTeam(ctx context.Context, userID int64, teamID int64) []string {
+	rows, err := s.db.QueryContext(ctx, `
+SELECT specialist_name
+FROM specialist_group_memberships
+WHERE user_id = ? AND group_id = ?
+ORDER BY LOWER(specialist_name)`, userID, teamID)
+	if err != nil {
+		return []string{}
+	}
+	defer rows.Close()
+	out := []string{}
+	for rows.Next() {
+		var member string
+		if err := rows.Scan(&member); err == nil {
+			out = append(out, member)
+		}
+	}
+	sortStrings(out)
+	return out
+}
+
+func (s *sqliteTeamStore) membersByTeamID(ctx context.Context, userID int64) (map[int64][]string, error) {
+	rows, err := s.db.QueryContext(ctx, `
+SELECT group_id, specialist_name
+FROM specialist_group_memberships
+WHERE user_id = ?
+ORDER BY group_id, LOWER(specialist_name)`, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := map[int64][]string{}
+	for rows.Next() {
+		var teamID int64
+		var member string
+		if err := rows.Scan(&teamID, &member); err != nil {
+			return nil, err
+		}
+		out[teamID] = append(out[teamID], member)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	for teamID := range out {
+		sortStrings(out[teamID])
+	}
+	return out, nil
+}
+
+func scanSQLiteSpecialistTeam(row interface{ Scan(dest ...any) error }) (persistence.SpecialistTeam, error) {
+	var team persistence.SpecialistTeam
+	var orchestrator string
+	if err := row.Scan(&team.ID, &team.UserID, &team.Name, &team.Description, &team.OrchestratorName, &orchestrator, &team.CreatedAt, &team.UpdatedAt); err != nil {
+		return persistence.SpecialistTeam{}, err
+	}
+	_ = json.Unmarshal([]byte(orchestrator), &team.Orchestrator)
+	return team, nil
 }
 
 type memTeamStore struct {

--- a/internal/persistence/databases/specialists_store.go
+++ b/internal/persistence/databases/specialists_store.go
@@ -2,9 +2,11 @@ package databases
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"strings"
+	"sync"
 
 	"manifold/internal/persistence"
 
@@ -17,6 +19,178 @@ func NewSpecialistsStore(pool *pgxpool.Pool) persistence.SpecialistsStore {
 		return &memSpecStore{m: map[int64]map[string]persistence.Specialist{}}
 	}
 	return &pgSpecStore{pool: pool}
+}
+
+type sqliteSpecStore struct {
+	db       *sql.DB
+	initOnce sync.Once
+	initErr  error
+}
+
+func NewSQLiteSpecialistsStore(db *sql.DB) persistence.SpecialistsStore {
+	return &sqliteSpecStore{db: db}
+}
+
+func (s *sqliteSpecStore) Init(ctx context.Context) error {
+	if s.db == nil {
+		return errors.New("sqlite specialists store requires db")
+	}
+	s.initOnce.Do(func() {
+		_, s.initErr = s.db.ExecContext(ctx, `
+CREATE TABLE IF NOT EXISTS specialists (
+	id INTEGER PRIMARY KEY AUTOINCREMENT,
+	user_id INTEGER NOT NULL DEFAULT 0,
+	name TEXT NOT NULL,
+	description TEXT NOT NULL DEFAULT '',
+	base_url TEXT NOT NULL DEFAULT '',
+	api_key TEXT NOT NULL DEFAULT '',
+	model TEXT NOT NULL DEFAULT '',
+	summary_context_window_tokens INTEGER NOT NULL DEFAULT 0,
+	enable_tools INTEGER NOT NULL DEFAULT 0,
+	request_info_enabled INTEGER DEFAULT NULL,
+	image_generation INTEGER NOT NULL DEFAULT 0,
+	auto_discover INTEGER DEFAULT NULL,
+	paused INTEGER NOT NULL DEFAULT 0,
+	allow_tools TEXT NOT NULL DEFAULT '[]' CHECK (json_valid(allow_tools)),
+	reasoning_effort TEXT NOT NULL DEFAULT '',
+	system TEXT NOT NULL DEFAULT '',
+	extra_headers TEXT NOT NULL DEFAULT '{}' CHECK (json_valid(extra_headers)),
+	extra_params TEXT NOT NULL DEFAULT '{}' CHECK (json_valid(extra_params)),
+	harness TEXT DEFAULT NULL,
+	provider TEXT NOT NULL DEFAULT '',
+	UNIQUE(user_id, name)
+);
+CREATE INDEX IF NOT EXISTS specialists_user_name_idx ON specialists(user_id, name);
+`)
+	})
+	return s.initErr
+}
+
+func (s *sqliteSpecStore) List(ctx context.Context, userID int64) ([]persistence.Specialist, error) {
+	if err := s.Init(ctx); err != nil {
+		return nil, err
+	}
+	rows, err := s.db.QueryContext(ctx, `SELECT id,user_id,name,description,base_url,api_key,model,summary_context_window_tokens,enable_tools,request_info_enabled,image_generation,auto_discover,paused,allow_tools,reasoning_effort,system,extra_headers,extra_params,harness,provider FROM specialists WHERE user_id=? ORDER BY LOWER(name)`, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := []persistence.Specialist{}
+	for rows.Next() {
+		sp, err := scanSQLiteSpecialist(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, sp)
+	}
+	return out, rows.Err()
+}
+
+func (s *sqliteSpecStore) GetByName(ctx context.Context, userID int64, name string) (persistence.Specialist, bool, error) {
+	if err := s.Init(ctx); err != nil {
+		return persistence.Specialist{}, false, err
+	}
+	row := s.db.QueryRowContext(ctx, `SELECT id,user_id,name,description,base_url,api_key,model,summary_context_window_tokens,enable_tools,request_info_enabled,image_generation,auto_discover,paused,allow_tools,reasoning_effort,system,extra_headers,extra_params,harness,provider FROM specialists WHERE user_id=? AND name=?`, userID, name)
+	sp, err := scanSQLiteSpecialist(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return persistence.Specialist{}, false, nil
+	}
+	if err != nil {
+		return persistence.Specialist{}, false, err
+	}
+	return sp, true, nil
+}
+
+func (s *sqliteSpecStore) Upsert(ctx context.Context, userID int64, sp persistence.Specialist) (persistence.Specialist, error) {
+	if strings.TrimSpace(sp.Name) == "" {
+		return persistence.Specialist{}, errors.New("name required")
+	}
+	if err := s.Init(ctx); err != nil {
+		return persistence.Specialist{}, err
+	}
+	allow, _ := json.Marshal(sp.AllowTools)
+	headers, _ := json.Marshal(sp.ExtraHeaders)
+	params, _ := json.Marshal(sp.ExtraParams)
+	harness := encodeSpecialistHarness(sp.Harness)
+	row := s.db.QueryRowContext(ctx, `
+INSERT INTO specialists(user_id,name,description,base_url,api_key,model,summary_context_window_tokens,enable_tools,request_info_enabled,image_generation,auto_discover,paused,allow_tools,reasoning_effort,system,extra_headers,extra_params,harness,provider)
+VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+ON CONFLICT(user_id, name) DO UPDATE SET
+	description=excluded.description,
+	base_url=excluded.base_url,
+	api_key=CASE
+		WHEN NULLIF(TRIM(excluded.api_key), '') IS NULL THEN specialists.api_key
+		ELSE excluded.api_key
+	END,
+	model=excluded.model,
+	summary_context_window_tokens=excluded.summary_context_window_tokens,
+	enable_tools=excluded.enable_tools,
+	request_info_enabled=excluded.request_info_enabled,
+	image_generation=excluded.image_generation,
+	auto_discover=excluded.auto_discover,
+	paused=excluded.paused,
+	allow_tools=excluded.allow_tools,
+	reasoning_effort=excluded.reasoning_effort,
+	system=excluded.system,
+	extra_headers=excluded.extra_headers,
+	extra_params=excluded.extra_params,
+	harness=excluded.harness,
+	provider=excluded.provider
+RETURNING id, api_key`, userID, sp.Name, sp.Description, sp.BaseURL, sp.APIKey, sp.Model, sp.SummaryContextWindowTokens, sp.EnableTools, nullableBool(sp.RequestInfoEnabled), sp.ImageGeneration, nullableBool(sp.AutoDiscover), sp.Paused, string(allow), sp.ReasoningEffort, sp.System, string(headers), string(params), nullableJSON(harness), sp.Provider)
+	if err := row.Scan(&sp.ID, &sp.APIKey); err != nil {
+		return persistence.Specialist{}, err
+	}
+	sp.UserID = userID
+	return sp, nil
+}
+
+func boolPtr(value bool) *bool {
+	return &value
+}
+
+func nullableBool(value *bool) any {
+	if value == nil {
+		return nil
+	}
+	return *value
+}
+
+func nullableJSON(raw []byte) any {
+	if len(raw) == 0 {
+		return nil
+	}
+	return string(raw)
+}
+
+func (s *sqliteSpecStore) Delete(ctx context.Context, userID int64, name string) error {
+	if err := s.Init(ctx); err != nil {
+		return err
+	}
+	_, err := s.db.ExecContext(ctx, `DELETE FROM specialists WHERE user_id=? AND name=?`, userID, name)
+	return err
+}
+
+func scanSQLiteSpecialist(row interface{ Scan(dest ...any) error }) (persistence.Specialist, error) {
+	var sp persistence.Specialist
+	var allow, headers, params string
+	var harness sql.NullString
+	var requestInfo, autoDiscover sql.NullBool
+	if err := row.Scan(&sp.ID, &sp.UserID, &sp.Name, &sp.Description, &sp.BaseURL, &sp.APIKey, &sp.Model, &sp.SummaryContextWindowTokens, &sp.EnableTools, &requestInfo, &sp.ImageGeneration, &autoDiscover, &sp.Paused, &allow, &sp.ReasoningEffort, &sp.System, &headers, &params, &harness, &sp.Provider); err != nil {
+		return persistence.Specialist{}, err
+	}
+	_ = json.Unmarshal([]byte(allow), &sp.AllowTools)
+	_ = json.Unmarshal([]byte(headers), &sp.ExtraHeaders)
+	_ = json.Unmarshal([]byte(params), &sp.ExtraParams)
+	if requestInfo.Valid {
+		sp.RequestInfoEnabled = boolPtr(requestInfo.Bool)
+	}
+	if autoDiscover.Valid {
+		sp.AutoDiscover = boolPtr(autoDiscover.Bool)
+	}
+	if harness.Valid {
+		sp.Harness = decodeSpecialistHarness([]byte(harness.String))
+	}
+	return sp, nil
 }
 
 type memSpecStore struct {

--- a/web/agentd-ui/src/api/client.ts
+++ b/web/agentd-ui/src/api/client.ts
@@ -175,7 +175,7 @@ export async function getTeam(name: string): Promise<SpecialistTeam> {
 export async function upsertTeam(
   team: SpecialistTeam,
 ): Promise<SpecialistTeam> {
-  if (team.name && team.id == null) {
+  if (team.name && (!Number.isFinite(team.id) || (team.id ?? 0) <= 0)) {
     const { data } = await apiClient.post<SpecialistTeam>("/teams", team);
     return data;
   }


### PR DESCRIPTION
## Summary

- Add `config.yaml.basic` as a minimal first-run config reference.
- Allow Manifold to start without a `config.yaml` by applying hardcoded defaults.
- Default first-run behavior to local SQLite, `$HOME/.manifold/projects`, env-based LLM provider selection, OpenAI embeddings, OpenAI image tooling, disabled forge harness, disabled reranking, and global memory off with memory subsystems ready for per-session opt-in.
- Update chat-session defaults so new sessions start with memory disabled across memory, SQLite, and Postgres stores.
- Default omitted OpenAI `api` settings to `responses`, while keeping explicit chat-completions and local-provider paths on `completions`.

## Validation

- `go test ./internal/...`
- `go test ./...`
- `go test ./internal/config ./internal/llm/openai ./internal/llm/providers ./cmd/agentd`