### PR TITLE
Add durable memory, decision archaeology, and secure storage foundations

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -524,6 +524,18 @@ memory:
       minSemanticWeight: 0.45
       lowConfidenceThreshold: 0.65
       requireReviewApproval: false
+      archiveBeforeDelete: true
+      requireCausalGrounding: false
+
+# Decision lineage and provenance memory. Disabled by default for rollout.
+archaeology:
+  enabled: false
+  archive_before_delete: true
+  decision_distiller: true
+  causal_grounding_required: true
+  reactor:
+    confidence_floor: 0.35
+    confidence_drop_delta: 0.30
 
 # Shared durable memory.
 transit:

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -291,6 +291,11 @@ auth:
     disablePKCE: false
 
 # Database backends.
+# SQLite and Postgres DB-backed specialist/MCP secrets require
+# MANIFOLD_SECRETS_KEY in the process environment. Generate it once with:
+#   openssl rand -base64 32
+# Keep the same key after backup/restore; losing it makes encrypted DB secrets
+# unrecoverable. Do not put the key in this YAML file.
 databases:
   # SQLite is the default durable backend. It lets Manifold run as a single
   # binary with no DATABASE_URL. Set backend=postgres and defaultDSN below for

--- a/docs/context_archaeology.md
+++ b/docs/context_archaeology.md
@@ -1,0 +1,92 @@
+# Context Archaeology
+
+Context archaeology records decisions as first-class memory objects so Manifold
+can later answer why a choice was made, what assumptions supported it, what
+alternatives were rejected, and whether those assumptions still hold.
+
+## Model
+
+- `decision.Decision` records the chosen path, rationale, decision actor, status,
+  review state, confidence, and source episode.
+- `decision.AssumptionLink` ties a decision to belief memory and snapshots the
+  belief statement/confidence at link time.
+- `decision.Alternative` records paths not taken and rejection reasons.
+- `decision.DecisionEvidence` links decisions to episodes, beliefs, transit
+  records, artifacts, and other source kinds.
+- `decision.Transition` is an append-only audit row for lifecycle changes.
+- `artifact.Artifact` stores immutable references to external objects such as git
+  commits, chat messages, tickets, documents, and transit key versions.
+
+## Lifecycle
+
+Valid decision status transitions are:
+
+- `proposed -> active | revoked`
+- `active -> stale | superseded | revoked`
+- `stale -> active | superseded | revoked`
+- `superseded` and `revoked` are terminal
+
+Same-status audit rows are permitted only for belief-change review flags.
+
+## Reactivity
+
+The belief notifying store emits non-blocking change events when belief status or
+confidence changes. The decision reactor applies these rules:
+
+- Retracted, superseded, or expired load-bearing beliefs mark linked decisions
+  `stale`.
+- Retracted, superseded, or expired supporting beliefs keep the decision active
+  but set `review_state=needs_review`.
+- Contextual beliefs add audit notes only.
+- Large confidence drops flag load-bearing decisions for review.
+
+The read path also checks current load-bearing assumptions, so a dropped async
+event degrades to eventual consistency rather than an incorrect verdict.
+
+## Reconstruction
+
+`archaeology.Service.Reconstruct` searches decisions, loads transitions,
+assumptions, alternatives, and evidence, resolves current belief and artifact
+state, optionally replays status as of a timestamp, and returns a verdict:
+
+- `holds`
+- `needs_review`
+- `stale`
+- `superseded`
+- `revoked`
+
+## Tools
+
+When archaeology is enabled, the agent tool registry exposes:
+
+- `decision_search` for retrieving recorded decisions by text, scope, and status.
+- `decision_reconstruct` for loading evidence, assumptions, alternatives, and
+  lifecycle transitions behind matching decisions.
+- `decision_record` for recording an explicit decision with optional evidence,
+  assumption links, and rejected alternatives.
+- `decision_review` for accepting/rejecting extracted candidates and updating
+  lifecycle state (`reaffirm`, `revoke`, `mark_stale`, `needs_review`).
+
+## Archival
+
+Evolving-memory pruning archives removed entries to a cold archive table when the
+store supports it. MAGMA lifecycle pruning writes archive nodes for events and
+edges before deletion when `archiveBeforeDelete` is enabled. If the archive write
+fails, the delete path stops and the hot record remains.
+
+## Configuration
+
+```yaml
+archaeology:
+  enabled: false
+  archive_before_delete: true
+  decision_distiller: true
+  causal_grounding_required: true
+  reactor:
+    confidence_floor: 0.35
+    confidence_drop_delta: 0.30
+```
+
+The feature is disabled by default. When disabled, decision and artifact stores
+can exist but no episode-end decision distillation or belief-to-decision reactor
+is attached.

--- a/docs/magma_memory.md
+++ b/docs/magma_memory.md
@@ -48,6 +48,7 @@ magma:
     minSemanticWeight: 0
     lowConfidenceThreshold: 0.6
     requireReviewApproval: false
+    requireCausalGrounding: false
 ```
 
 Lifecycle defaults are conservative:
@@ -58,6 +59,20 @@ Lifecycle defaults are conservative:
 - `minSemanticWeight: 0` disables semantic edge pruning by weight.
 - `lowConfidenceThreshold` controls which edges are flagged as `needs_review` during lifecycle pruning.
 - `requireReviewApproval: true` makes retrieval ignore review-flagged edges until they are approved.
+- `requireCausalGrounding: true` marks ungrounded LLM causal edges as `needs_review`.
+
+## Causal Edge Provenance
+
+Causal edges standardize these `Edge.Props` keys:
+
+- `origin`: `llm_consolidation`, `operator`, `distiller`, or `import`.
+- `model`: the model name when the edge came from an LLM.
+- `confidence`: extraction confidence.
+- `evidence`: a list of `{sourceKind, sourceId}` references.
+- `approved_at` and `approved_by`: operator approval metadata.
+
+`GroundEdge` appends evidence references and clears `review_state=needs_review`
+when the only review reason was `ungrounded_causal`.
 
 ## Write Path
 

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -7,6 +7,18 @@ No `DATABASE_URL` is required for local or single-binary deployments.
 
 ## Durable Database
 
+SQLite and Postgres DB-backed specialist/MCP secrets are encrypted at the
+application layer. Set `MANIFOLD_SECRETS_KEY` in the process environment before
+starting Manifold:
+
+```bash
+MANIFOLD_SECRETS_KEY=$(openssl rand -base64 32)
+```
+
+Generate this value once per deployment and keep it with your operational
+secrets. The same key is required after backup/restore. If the key is lost,
+encrypted database secrets cannot be recovered.
+
 The default database configuration is:
 
 ```yaml

--- a/example.env
+++ b/example.env
@@ -17,6 +17,11 @@ AUTH_CLIENT_SECRET=""
 # Set this and configure databases.backend=postgres when you want Postgres.
 DATABASE_URL=""
 
+# Required when SQLite or Postgres stores specialist/MCP secrets in the DB.
+# Generate once with: openssl rand -base64 32
+# Keep the same value for backup/restore; losing it makes encrypted DB secrets unrecoverable.
+MANIFOLD_SECRETS_KEY=""
+
 # Optional persistent telemetry backend. Leave empty for process-local telemetry
 # with no ClickHouse or OpenTelemetry Collector.
 CLICKHOUSE_DSN=""

--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,7 @@ require (
 	go.opentelemetry.io/otel/sdk/log v0.19.0
 	go.opentelemetry.io/otel/sdk/metric v1.43.0
 	go.opentelemetry.io/otel/trace v1.43.0
+	golang.org/x/crypto v0.52.0
 	golang.org/x/net v0.54.0
 	golang.org/x/oauth2 v0.35.0
 	golang.org/x/sync v0.20.0
@@ -106,7 +107,6 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
-	golang.org/x/crypto v0.52.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/text v0.37.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9 // indirect

--- a/internal/agent/engine.go
+++ b/internal/agent/engine.go
@@ -5,7 +5,9 @@ import (
 
 	"manifold/internal/agent/harness"
 	"manifold/internal/agent/memory"
+	"manifold/internal/agent/memory/artifact"
 	"manifold/internal/agent/memory/belief"
+	"manifold/internal/agent/memory/decision"
 	"manifold/internal/llm"
 	"manifold/internal/policy"
 	"manifold/internal/tools"
@@ -48,6 +50,9 @@ type Engine struct {
 	BeliefLifecyclePolicy        belief.PromotionPolicy
 	BeliefPolicySink             belief.PolicySink
 	BeliefMagmaSink              BeliefMagmaSink
+	DecisionStore                decision.Store
+	DecisionDistiller            decision.Distiller
+	ArtifactCapture              *artifact.CaptureManager
 	BeliefEnforcementPolicy      belief.EnforcementPolicy
 	PolicyEnforcer               policy.Enforcer
 	// MaxToolParallelism controls how many tool calls may run concurrently within a single step.

--- a/internal/agent/engine_episodes.go
+++ b/internal/agent/engine_episodes.go
@@ -3,8 +3,11 @@ package agent
 import (
 	"context"
 	"manifold/internal/agent/memory"
+	"manifold/internal/agent/memory/artifact"
 	"manifold/internal/agent/memory/belief"
+	"manifold/internal/agent/memory/decision"
 	"manifold/internal/observability"
+	"os"
 	"strings"
 	"time"
 
@@ -112,7 +115,90 @@ func (e *Engine) recordRunEpisode(ctx context.Context, record runEpisodeRecord) 
 		observability.LoggerWithTrace(ctx).Warn().Err(err).Msg("belief_episode_store_failed")
 		return
 	}
+	captured := e.captureArtifacts(ctx, episode)
 	e.distillBeliefs(ctx, episode, record.userInput, record.final, record.reasoningTrace)
+	e.distillDecisions(ctx, episode, record.userInput, record.final, record.reasoningTrace, captured)
+}
+
+func (e *Engine) captureArtifacts(ctx context.Context, episode belief.Episode) []artifact.Artifact {
+	if e == nil || e.ArtifactCapture == nil {
+		return nil
+	}
+	hints := map[string]string{
+		"sessionID": strings.TrimSpace(episode.SessionID),
+		"since":     episode.StartedAt.Format(time.RFC3339),
+	}
+	if episode.EndedAt != nil && !episode.EndedAt.IsZero() {
+		hints["until"] = episode.EndedAt.Format(time.RFC3339)
+	}
+	if info, err := os.Stat(e.ProjectID); err == nil && info.IsDir() {
+		hints["repoPath"] = e.ProjectID
+	}
+	return e.ArtifactCapture.Capture(ctx, artifact.CaptureRequest{
+		TenantID:  episode.TenantID,
+		ScopeID:   episode.ScopeID,
+		EpisodeID: episode.ID,
+		Hints:     hints,
+	})
+}
+
+func (e *Engine) distillDecisions(ctx context.Context, episode belief.Episode, userInput, final string, reasoningTrace []string, artifacts []artifact.Artifact) {
+	if e == nil || e.DisableBeliefMemory || e.DecisionStore == nil || e.DecisionDistiller == nil {
+		return
+	}
+	refs := make([]decision.ArtifactRef, 0, len(artifacts))
+	for _, item := range artifacts {
+		refs = append(refs, decision.ArtifactRef{
+			ID:         item.ID,
+			Kind:       string(item.Kind),
+			ExternalID: item.ExternalID,
+			URI:        item.URI,
+			Title:      item.Title,
+			Excerpt:    item.Excerpt,
+		})
+	}
+	input := decision.DistillationInput{
+		Episode:        episode,
+		UserRequest:    userInput,
+		FinalAnswer:    final,
+		Summary:        final,
+		ReasoningTrace: append([]string(nil), reasoningTrace...),
+		Artifacts:      refs,
+	}
+	var candidates []decision.Candidate
+	var audit []decision.Candidate
+	if distiller, ok := e.DecisionDistiller.(decision.AuditDistiller); ok {
+		result, err := distiller.DistillWithAudit(ctx, input)
+		if err != nil {
+			observability.LoggerWithTrace(ctx).Warn().Err(err).Str("episode_id", episode.ID).Msg("decision_distillation_failed")
+			return
+		}
+		candidates = result.Candidates
+		audit = result.Audit
+	} else {
+		var err error
+		candidates, err = e.DecisionDistiller.Distill(ctx, input)
+		if err != nil {
+			observability.LoggerWithTrace(ctx).Warn().Err(err).Str("episode_id", episode.ID).Msg("decision_distillation_failed")
+			return
+		}
+		audit = candidates
+	}
+	for _, record := range audit {
+		if record.TenantID == 0 {
+			record.TenantID = episode.TenantID
+		}
+		if record.EpisodeID == "" {
+			record.EpisodeID = episode.ID
+		}
+		if record.ScopeID == "" {
+			record.ScopeID = episode.ScopeID
+		}
+		if _, err := e.DecisionStore.RecordCandidate(ctx, record); err != nil {
+			observability.LoggerWithTrace(ctx).Warn().Err(err).Str("episode_id", episode.ID).Msg("decision_candidate_audit_failed")
+		}
+	}
+	observability.LoggerWithTrace(ctx).Info().Int("candidate_count", len(candidates)).Str("episode_id", episode.ID).Msg("decision_distillation_queued")
 }
 
 func (e *Engine) distillBeliefs(ctx context.Context, episode belief.Episode, userInput, final string, reasoningTrace []string) {

--- a/internal/agent/memory/archaeology/report.go
+++ b/internal/agent/memory/archaeology/report.go
@@ -1,0 +1,48 @@
+package archaeology
+
+import (
+	"time"
+
+	"manifold/internal/agent/memory/artifact"
+	"manifold/internal/agent/memory/belief"
+	"manifold/internal/agent/memory/decision"
+)
+
+// ReconstructOptions tunes a decision archaeology query.
+type ReconstructOptions struct {
+	ScopeIDs     []string
+	AsOf         *time.Time
+	IncludeStale bool
+	MaxDecisions int
+}
+
+// Report is the top-level reconstruction result.
+type Report struct {
+	Decisions []DecisionDossier `json:"decisions"`
+}
+
+// DecisionDossier contains the recovered context around one decision.
+type DecisionDossier struct {
+	Decision     decision.Decision      `json:"decision"`
+	Transitions  []decision.Transition  `json:"transitions,omitempty"`
+	Assumptions  []AssumptionStatus     `json:"assumptions,omitempty"`
+	Alternatives []decision.Alternative `json:"alternatives,omitempty"`
+	Evidence     []EvidenceResolved     `json:"evidence,omitempty"`
+	Verdict      string                 `json:"verdict"`
+	Narrative    string                 `json:"narrative,omitempty"`
+}
+
+// AssumptionStatus compares the belief snapshot at decision time with current state.
+type AssumptionStatus struct {
+	Link       decision.AssumptionLink `json:"link"`
+	BeliefNow  *belief.Belief          `json:"beliefNow,omitempty"`
+	StillHolds bool                    `json:"stillHolds"`
+}
+
+// EvidenceResolved resolves known decision evidence source types.
+type EvidenceResolved struct {
+	Evidence decision.DecisionEvidence `json:"evidence"`
+	Artifact *artifact.Artifact        `json:"artifact,omitempty"`
+	Belief   *belief.Belief            `json:"belief,omitempty"`
+	Episode  *belief.Episode           `json:"episode,omitempty"`
+}

--- a/internal/agent/memory/archaeology/service.go
+++ b/internal/agent/memory/archaeology/service.go
@@ -1,0 +1,163 @@
+package archaeology
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"manifold/internal/agent/memory/artifact"
+	"manifold/internal/agent/memory/belief"
+	"manifold/internal/agent/memory/decision"
+)
+
+// Service reconstructs why a decision exists and whether its assumptions hold.
+type Service struct {
+	Decisions *decision.Service
+	Beliefs   belief.Store
+	Artifacts artifact.Store
+	Config    ServiceConfig
+}
+
+// ServiceConfig tunes reconstruction verdicts.
+type ServiceConfig struct {
+	ConfidenceFloor float64
+}
+
+// Reconstruct answers why a decision exists.
+func (s *Service) Reconstruct(ctx context.Context, tenantID int64, query string, opts ReconstructOptions) (Report, error) {
+	if s == nil || s.Decisions == nil || s.Decisions.Store == nil {
+		return Report{}, decision.ErrStoreRequired
+	}
+	limit := opts.MaxDecisions
+	if limit <= 0 {
+		limit = 5
+	}
+	statuses := []decision.DecisionStatus{
+		decision.DecisionStatusProposed,
+		decision.DecisionStatusActive,
+		decision.DecisionStatusStale,
+		decision.DecisionStatusSuperseded,
+		decision.DecisionStatusRevoked,
+	}
+	if !opts.IncludeStale {
+		statuses = []decision.DecisionStatus{decision.DecisionStatusActive, decision.DecisionStatusProposed}
+	}
+	results, err := s.Decisions.Store.SearchDecisions(ctx, decision.SearchQuery{
+		TenantID: tenantID,
+		ScopeIDs: opts.ScopeIDs,
+		Query:    query,
+		Statuses: statuses,
+		Limit:    limit,
+	})
+	if err != nil {
+		return Report{}, err
+	}
+	report := Report{Decisions: make([]DecisionDossier, 0, len(results))}
+	for _, result := range results {
+		dossier, err := s.loadDossier(ctx, tenantID, result.Decision.ID, opts)
+		if err != nil {
+			return Report{}, err
+		}
+		report.Decisions = append(report.Decisions, dossier)
+	}
+	return report, nil
+}
+
+func (s *Service) loadDossier(ctx context.Context, tenantID int64, decisionID string, opts ReconstructOptions) (DecisionDossier, error) {
+	lineage, ok, err := s.Decisions.LoadLineage(ctx, tenantID, decisionID)
+	if err != nil || !ok {
+		return DecisionDossier{}, err
+	}
+	item := lineage.Decision
+	if opts.AsOf != nil {
+		item.Status = statusAsOf(item.Status, lineage.Transitions, *opts.AsOf)
+	}
+	assumptions := make([]AssumptionStatus, 0, len(lineage.Assumptions))
+	for _, link := range lineage.Assumptions {
+		status := AssumptionStatus{Link: link, StillHolds: true}
+		if s.Beliefs != nil && strings.TrimSpace(link.BeliefID) != "" {
+			if b, ok, err := s.Beliefs.GetBelief(ctx, tenantID, link.BeliefID); err == nil && ok {
+				status.BeliefNow = &b
+				status.StillHolds = b.Status == belief.BeliefStatusActive && b.Confidence >= s.confidenceFloor()
+			} else {
+				status.StillHolds = false
+			}
+		}
+		assumptions = append(assumptions, status)
+	}
+	evidence := make([]EvidenceResolved, 0, len(lineage.Evidence))
+	for _, ev := range lineage.Evidence {
+		resolved := EvidenceResolved{Evidence: ev}
+		switch ev.SourceKind {
+		case string(belief.SourceKindArtifact):
+			if s.Artifacts != nil {
+				if item, ok, err := s.Artifacts.GetArtifact(ctx, tenantID, ev.SourceID); err == nil && ok {
+					resolved.Artifact = &item
+				}
+			}
+		case string(belief.SourceKindBelief):
+			if s.Beliefs != nil {
+				if item, ok, err := s.Beliefs.GetBelief(ctx, tenantID, ev.SourceID); err == nil && ok {
+					resolved.Belief = &item
+				}
+			}
+		case string(belief.SourceKindEpisode):
+			if s.Beliefs != nil {
+				if item, ok, err := s.Beliefs.GetEpisode(ctx, tenantID, ev.SourceID); err == nil && ok {
+					resolved.Episode = &item
+				}
+			}
+		}
+		evidence = append(evidence, resolved)
+	}
+	dossier := DecisionDossier{
+		Decision:     item,
+		Transitions:  lineage.Transitions,
+		Assumptions:  assumptions,
+		Alternatives: lineage.Alternatives,
+		Evidence:     evidence,
+	}
+	dossier.Verdict = verdict(item, assumptions)
+	return dossier, nil
+}
+
+func statusAsOf(current decision.DecisionStatus, transitions []decision.Transition, asOfTime time.Time) decision.DecisionStatus {
+	status := current
+	for _, tr := range transitions {
+		if tr.CreatedAt.After(asOfTime) {
+			break
+		}
+		status = tr.ToStatus
+	}
+	if status == "" {
+		return decision.DecisionStatusActive
+	}
+	return status
+}
+
+func verdict(item decision.Decision, assumptions []AssumptionStatus) string {
+	switch item.Status {
+	case decision.DecisionStatusSuperseded:
+		return "superseded"
+	case decision.DecisionStatusRevoked:
+		return "revoked"
+	case decision.DecisionStatusStale:
+		return "stale"
+	}
+	if item.ReviewState == decision.ReviewStateNeedsReview {
+		return "needs_review"
+	}
+	for _, assumption := range assumptions {
+		if decision.NormalizeAssumptionCriticality(assumption.Link.Criticality) == decision.CriticalityLoadBearing && !assumption.StillHolds {
+			return "stale"
+		}
+	}
+	return "holds"
+}
+
+func (s *Service) confidenceFloor() float64 {
+	if s == nil || s.Config.ConfidenceFloor <= 0 {
+		return 0.35
+	}
+	return s.Config.ConfidenceFloor
+}

--- a/internal/agent/memory/archaeology/service_test.go
+++ b/internal/agent/memory/archaeology/service_test.go
@@ -1,0 +1,61 @@
+package archaeology
+
+import (
+	"context"
+	"testing"
+
+	"manifold/internal/agent/memory/artifact"
+	"manifold/internal/agent/memory/belief"
+	"manifold/internal/agent/memory/decision"
+	"manifold/internal/persistence/databases"
+)
+
+func TestReconstructReportsStaleLoadBearingAssumption(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	decisionStore := databases.NewMemoryDecisionStore()
+	beliefStore := databases.NewMemoryBeliefStore()
+	artifactStore := databases.NewMemoryArtifactStore()
+	scope, err := beliefStore.EnsureScope(ctx, belief.Scope{TenantID: 7, Kind: belief.ScopeKindProject, Path: "project", Label: "project"})
+	if err != nil {
+		t.Fatalf("EnsureScope: %v", err)
+	}
+	b, err := beliefStore.UpsertBelief(ctx, belief.Belief{
+		TenantID:      7,
+		ScopeID:       scope.ID,
+		Statement:     "Postgres is available.",
+		StatementHash: belief.StatementHash("Postgres is available."),
+		Confidence:    0.2,
+		Status:        belief.BeliefStatusActive,
+	})
+	if err != nil {
+		t.Fatalf("UpsertBelief: %v", err)
+	}
+	service := &decision.Service{Store: decisionStore, Belief: beliefStore}
+	d, err := service.CreateDecision(ctx, decision.Decision{TenantID: 7, ScopeID: scope.ID, Statement: "Use pgvector for memory search.", Status: decision.DecisionStatusActive})
+	if err != nil {
+		t.Fatalf("CreateDecision: %v", err)
+	}
+	_, err = decisionStore.AddAssumption(ctx, decision.AssumptionLink{TenantID: 7, DecisionID: d.ID, BeliefID: b.ID, Criticality: decision.CriticalityLoadBearing, BeliefStatementAtLink: b.Statement, BeliefConfidenceAtLink: 0.9})
+	if err != nil {
+		t.Fatalf("AddAssumption: %v", err)
+	}
+	art, err := artifactStore.UpsertArtifact(ctx, artifact.Artifact{TenantID: 7, Kind: artifact.ArtifactGitCommit, ExternalID: "abc", Title: "commit", Excerpt: "decision evidence"})
+	if err != nil {
+		t.Fatalf("UpsertArtifact: %v", err)
+	}
+	_, err = decisionStore.AddEvidence(ctx, decision.DecisionEvidence{TenantID: 7, DecisionID: d.ID, SourceKind: "artifact", SourceID: art.ID})
+	if err != nil {
+		t.Fatalf("AddEvidence: %v", err)
+	}
+	report, err := (&Service{Decisions: service, Beliefs: beliefStore, Artifacts: artifactStore}).Reconstruct(ctx, 7, "pgvector", ReconstructOptions{ScopeIDs: []string{scope.ID}})
+	if err != nil {
+		t.Fatalf("Reconstruct: %v", err)
+	}
+	if len(report.Decisions) != 1 {
+		t.Fatalf("expected one dossier, got %+v", report)
+	}
+	if report.Decisions[0].Verdict != "stale" || report.Decisions[0].Evidence[0].Artifact == nil {
+		t.Fatalf("unexpected dossier: %+v", report.Decisions[0])
+	}
+}

--- a/internal/agent/memory/artifact/connectors/capture_test.go
+++ b/internal/agent/memory/artifact/connectors/capture_test.go
@@ -1,0 +1,174 @@
+package connectors
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"manifold/internal/agent/memory/artifact"
+	"manifold/internal/persistence"
+	"manifold/internal/transit"
+)
+
+func TestChatConnectorCapturesSessionMessages(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC)
+	store := &fakeChatStore{messages: []persistence.ChatMessage{
+		{ID: "old", SessionID: "session-1", Role: "user", Content: "old message", CreatedAt: now.Add(-time.Hour)},
+		{ID: "new", SessionID: "session-1", Role: "assistant", Content: "we chose postgres jsonb", CreatedAt: now},
+	}}
+	connector := ChatConnector{Store: store}
+	items, err := connector.Capture(context.Background(), artifact.CaptureRequest{
+		TenantID: 7,
+		ScopeID:  "scope-1",
+		Hints: map[string]string{
+			"sessionID": "session-1",
+			"since":     now.Add(-time.Minute).Format(time.RFC3339),
+		},
+	})
+	if err != nil {
+		t.Fatalf("Capture() error = %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected one captured message, got %d", len(items))
+	}
+	item := items[0]
+	if item.Kind != artifact.ArtifactChatMessage || item.ExternalID != "session-1:new" || item.ContentHash == "" {
+		t.Fatalf("unexpected chat artifact: %#v", item)
+	}
+	if item.Excerpt != "we chose postgres jsonb" || item.Metadata["sessionId"] != "session-1" {
+		t.Fatalf("unexpected chat artifact content: %#v", item)
+	}
+}
+
+func TestTransitConnectorCapturesExplicitKeys(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC)
+	store := &fakeTransitStore{records: map[string]transit.Record{
+		"project/demo/decision": {
+			TenantID:    7,
+			KeyName:     "project/demo/decision",
+			Description: "Decision note",
+			Value:       "Use causal grounding for lifecycle transitions.",
+			Version:     3,
+			UpdatedBy:   42,
+			UpdatedAt:   now,
+		},
+	}}
+	connector := TransitConnector{Store: store}
+	items, err := connector.Capture(context.Background(), artifact.CaptureRequest{
+		TenantID: 7,
+		Hints:    map[string]string{"keys": "project/demo/decision, project/demo/decision"},
+	})
+	if err != nil {
+		t.Fatalf("Capture() error = %v", err)
+	}
+	if len(store.keys) != 1 || store.keys[0] != "project/demo/decision" {
+		t.Fatalf("expected deduped requested keys, got %#v", store.keys)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected one transit artifact, got %d", len(items))
+	}
+	item := items[0]
+	if item.Kind != artifact.ArtifactTransitKey || item.ExternalID != "project/demo/decision@v3" || item.ContentHash == "" {
+		t.Fatalf("unexpected transit artifact: %#v", item)
+	}
+	if item.AuthoredBy != "42" || item.Metadata["version"] != int64(3) {
+		t.Fatalf("unexpected transit metadata: %#v", item)
+	}
+}
+
+type fakeChatStore struct {
+	messages []persistence.ChatMessage
+}
+
+func (f *fakeChatStore) Init(context.Context) error { return nil }
+func (f *fakeChatStore) EnsureSession(context.Context, *int64, string, string) (persistence.ChatSession, error) {
+	return persistence.ChatSession{}, nil
+}
+func (f *fakeChatStore) EnsureSessionKind(context.Context, *int64, string, string, string) (persistence.ChatSession, error) {
+	return persistence.ChatSession{}, nil
+}
+func (f *fakeChatStore) ListSessions(context.Context, *int64) ([]persistence.ChatSession, error) {
+	return nil, nil
+}
+func (f *fakeChatStore) ListSessionsByKind(context.Context, *int64, string) ([]persistence.ChatSession, error) {
+	return nil, nil
+}
+func (f *fakeChatStore) GetSession(context.Context, *int64, string) (persistence.ChatSession, error) {
+	return persistence.ChatSession{}, nil
+}
+func (f *fakeChatStore) CreateSession(context.Context, *int64, string) (persistence.ChatSession, error) {
+	return persistence.ChatSession{}, nil
+}
+func (f *fakeChatStore) CreateSessionKind(context.Context, *int64, string, string) (persistence.ChatSession, error) {
+	return persistence.ChatSession{}, nil
+}
+func (f *fakeChatStore) RenameSession(context.Context, *int64, string, string) (persistence.ChatSession, error) {
+	return persistence.ChatSession{}, nil
+}
+func (f *fakeChatStore) SetSessionProject(context.Context, *int64, string, string) (persistence.ChatSession, error) {
+	return persistence.ChatSession{}, nil
+}
+func (f *fakeChatStore) SetSessionMemorySettings(context.Context, *int64, string, bool, bool, bool) (persistence.ChatSession, error) {
+	return persistence.ChatSession{}, nil
+}
+func (f *fakeChatStore) DeleteSession(context.Context, *int64, string) error { return nil }
+func (f *fakeChatStore) ListMessages(_ context.Context, _ *int64, sessionID string, limit int) ([]persistence.ChatMessage, error) {
+	out := []persistence.ChatMessage{}
+	for _, msg := range f.messages {
+		if msg.SessionID == sessionID {
+			out = append(out, msg)
+		}
+	}
+	if limit > 0 && len(out) > limit {
+		out = out[len(out)-limit:]
+	}
+	return out, nil
+}
+func (f *fakeChatStore) DeleteMessage(context.Context, *int64, string, string) error { return nil }
+func (f *fakeChatStore) DeleteMessagesAfter(context.Context, *int64, string, string, bool) error {
+	return nil
+}
+func (f *fakeChatStore) AppendMessages(context.Context, *int64, string, []persistence.ChatMessage, string, string) error {
+	return nil
+}
+func (f *fakeChatStore) AppendMessagesOnce(context.Context, *int64, string, []persistence.ChatMessage, string, string) error {
+	return nil
+}
+func (f *fakeChatStore) UpdateSummary(context.Context, *int64, string, string, int) error {
+	return nil
+}
+
+type fakeTransitStore struct {
+	records map[string]transit.Record
+	keys    []string
+}
+
+func (f *fakeTransitStore) Init(context.Context) error { return nil }
+func (f *fakeTransitStore) Create(context.Context, int64, int64, []transit.CreateMemoryItem) ([]transit.Record, error) {
+	return nil, nil
+}
+func (f *fakeTransitStore) Get(_ context.Context, _ int64, keys []string) ([]transit.Record, error) {
+	f.keys = append([]string(nil), keys...)
+	out := []transit.Record{}
+	for _, key := range keys {
+		if record, ok := f.records[key]; ok {
+			out = append(out, record)
+		}
+	}
+	return out, nil
+}
+func (f *fakeTransitStore) Update(context.Context, int64, int64, transit.UpdateMemoryRequest) (transit.Record, error) {
+	return transit.Record{}, nil
+}
+func (f *fakeTransitStore) Delete(context.Context, int64, []string) error { return nil }
+func (f *fakeTransitStore) ListKeys(context.Context, int64, transit.ListRequest) ([]transit.Metadata, error) {
+	return nil, nil
+}
+func (f *fakeTransitStore) ListRecent(context.Context, int64, transit.ListRequest) ([]transit.Metadata, error) {
+	return nil, nil
+}
+func (f *fakeTransitStore) SearchText(context.Context, int64, transit.SearchRequest) ([]transit.SearchCandidate, error) {
+	return nil, nil
+}

--- a/internal/agent/memory/artifact/connectors/chat.go
+++ b/internal/agent/memory/artifact/connectors/chat.go
@@ -1,0 +1,127 @@
+package connectors
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"manifold/internal/agent/memory/artifact"
+	"manifold/internal/persistence"
+)
+
+const defaultChatCaptureLimit = 100
+
+// ChatConnector captures chat messages for the active session.
+type ChatConnector struct {
+	Store persistence.ChatStore
+	Limit int
+}
+
+// Kind returns the artifact kind captured by this connector.
+func (ChatConnector) Kind() artifact.ArtifactKind { return artifact.ArtifactChatMessage }
+
+// Capture captures messages for the requested chat session. Hints: sessionID, limit, since, until.
+func (c ChatConnector) Capture(ctx context.Context, req artifact.CaptureRequest) ([]artifact.Artifact, error) {
+	if c.Store == nil {
+		return nil, artifact.ErrConnectorUnavailable
+	}
+	sessionID := strings.TrimSpace(req.Hints["sessionID"])
+	if sessionID == "" {
+		return nil, artifact.ErrConnectorUnavailable
+	}
+	limit := c.Limit
+	if limit <= 0 {
+		limit = defaultChatCaptureLimit
+	}
+	if hinted := strings.TrimSpace(req.Hints["limit"]); hinted != "" {
+		parsed, err := strconv.Atoi(hinted)
+		if err != nil {
+			return nil, err
+		}
+		if parsed > 0 {
+			limit = parsed
+		}
+	}
+	since, err := parseOptionalRFC3339(req.Hints["since"])
+	if err != nil {
+		return nil, err
+	}
+	until, err := parseOptionalRFC3339(req.Hints["until"])
+	if err != nil {
+		return nil, err
+	}
+	userID := req.TenantID
+	messages, err := c.Store.ListMessages(ctx, &userID, sessionID, limit)
+	if err != nil {
+		return nil, err
+	}
+	now := time.Now().UTC()
+	out := make([]artifact.Artifact, 0, len(messages))
+	for i, msg := range messages {
+		if !since.IsZero() && msg.CreatedAt.Before(since) {
+			continue
+		}
+		if !until.IsZero() && msg.CreatedAt.After(until) {
+			continue
+		}
+		excerpt := strings.TrimSpace(msg.Content)
+		if excerpt == "" {
+			continue
+		}
+		messageID := strings.TrimSpace(msg.ID)
+		if messageID == "" {
+			messageID = fmt.Sprintf("%d", i)
+		}
+		content := strings.TrimSpace(msg.Role) + "\n" + excerpt
+		hash := sha256.Sum256([]byte(content))
+		title := strings.TrimSpace(msg.Title)
+		if title == "" {
+			title = strings.TrimSpace(msg.Role)
+			if title == "" {
+				title = "chat"
+			}
+			title += " message"
+		}
+		authoredAt := msg.CreatedAt
+		if authoredAt.IsZero() {
+			authoredAt = now
+		}
+		out = append(out, artifact.Artifact{
+			TenantID:    req.TenantID,
+			Kind:        artifact.ArtifactChatMessage,
+			ExternalID:  sessionID + ":" + messageID,
+			URI:         chatMessageURI(sessionID, messageID),
+			Title:       title,
+			Excerpt:     truncateBytes(excerpt, maxArtifactExcerptBytes),
+			ContentHash: fmt.Sprintf("%x", hash),
+			AuthoredBy:  strings.TrimSpace(msg.Role),
+			AuthoredAt:  authoredAt,
+			CapturedAt:  now,
+			Metadata: map[string]any{
+				"sessionId": sessionID,
+				"messageId": messageID,
+				"role":      strings.TrimSpace(msg.Role),
+				"scopeId":   strings.TrimSpace(req.ScopeID),
+				"episodeId": strings.TrimSpace(req.EpisodeID),
+				"toolId":    strings.TrimSpace(msg.ToolID),
+			},
+		})
+	}
+	return out, nil
+}
+
+func chatMessageURI(sessionID, messageID string) string {
+	return "chat://" + url.PathEscape(sessionID) + "#" + url.QueryEscape(messageID)
+}
+
+func parseOptionalRFC3339(value string) (time.Time, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return time.Time{}, nil
+	}
+	return time.Parse(time.RFC3339, value)
+}

--- a/internal/agent/memory/artifact/connectors/git.go
+++ b/internal/agent/memory/artifact/connectors/git.go
@@ -1,0 +1,109 @@
+package connectors
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"net/url"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"manifold/internal/agent/memory/artifact"
+)
+
+const maxArtifactExcerptBytes = 8 << 10
+
+// GitConnector captures git commits from a local repository path.
+type GitConnector struct{}
+
+// Kind returns the artifact kind captured by this connector.
+func (GitConnector) Kind() artifact.ArtifactKind { return artifact.ArtifactGitCommit }
+
+// Capture captures commits since the requested time. Hints: repoPath, since, branch.
+func (GitConnector) Capture(ctx context.Context, req artifact.CaptureRequest) ([]artifact.Artifact, error) {
+	repoPath := strings.TrimSpace(req.Hints["repoPath"])
+	if repoPath == "" {
+		return nil, artifact.ErrConnectorUnavailable
+	}
+	repoPath, err := filepath.Abs(repoPath)
+	if err != nil {
+		return nil, err
+	}
+	args := []string{"-C", repoPath, "log", "--format=%H%x1f%an%x1f%aI%x1f%s%x1f%b%x1e"}
+	if since := strings.TrimSpace(req.Hints["since"]); since != "" {
+		args = append(args, "--since="+since)
+	}
+	if branch := strings.TrimSpace(req.Hints["branch"]); branch != "" {
+		args = append(args, branch)
+	}
+	cmd := exec.CommandContext(ctx, "git", args...)
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+	return parseGitLog(req.TenantID, repoPath, output), nil
+}
+
+func parseGitLog(tenantID int64, repoPath string, output []byte) []artifact.Artifact {
+	out := []artifact.Artifact{}
+	scanner := bufio.NewScanner(bytes.NewReader(output))
+	scanner.Split(splitRecords)
+	now := time.Now().UTC()
+	for scanner.Scan() {
+		record := strings.Trim(scanner.Text(), "\x1e\n\r\t ")
+		if record == "" {
+			continue
+		}
+		parts := strings.SplitN(record, "\x1f", 5)
+		if len(parts) < 5 {
+			continue
+		}
+		sha := strings.TrimSpace(parts[0])
+		author := strings.TrimSpace(parts[1])
+		authoredAt, _ := time.Parse(time.RFC3339, strings.TrimSpace(parts[2]))
+		subject := strings.TrimSpace(parts[3])
+		body := strings.TrimSpace(parts[4])
+		content := strings.TrimSpace(subject + "\n\n" + body)
+		hash := sha256.Sum256([]byte(content))
+		out = append(out, artifact.Artifact{
+			TenantID:    tenantID,
+			Kind:        artifact.ArtifactGitCommit,
+			ExternalID:  sha,
+			URI:         gitFileURI(repoPath, sha),
+			Title:       subject,
+			Excerpt:     truncateBytes(content, maxArtifactExcerptBytes),
+			ContentHash: fmt.Sprintf("%x", hash),
+			AuthoredBy:  author,
+			AuthoredAt:  authoredAt,
+			CapturedAt:  now,
+			Metadata:    map[string]any{"repoPath": repoPath},
+		})
+	}
+	return out
+}
+
+func splitRecords(data []byte, atEOF bool) (advance int, token []byte, err error) {
+	if i := bytes.IndexByte(data, 0x1e); i >= 0 {
+		return i + 1, data[:i], nil
+	}
+	if atEOF && len(data) > 0 {
+		return len(data), data, nil
+	}
+	return 0, nil, nil
+}
+
+func gitFileURI(repoPath, sha string) string {
+	u := url.URL{Scheme: "file", Path: repoPath}
+	return u.String() + "#" + sha
+}
+
+func truncateBytes(text string, limit int) string {
+	if limit <= 0 || len(text) <= limit {
+		return text
+	}
+	return text[:limit]
+}

--- a/internal/agent/memory/artifact/connectors/git_test.go
+++ b/internal/agent/memory/artifact/connectors/git_test.go
@@ -1,0 +1,47 @@
+package connectors
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"manifold/internal/agent/memory/artifact"
+	"manifold/internal/persistence/databases"
+)
+
+func TestGitConnectorCapturesCommitsIdempotently(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	repo := t.TempDir()
+	runGit(t, repo, "init")
+	runGit(t, repo, "config", "user.email", "test@example.com")
+	runGit(t, repo, "config", "user.name", "Test User")
+	if err := os.WriteFile(filepath.Join(repo, "README.md"), []byte("hello\n"), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	runGit(t, repo, "add", "README.md")
+	runGit(t, repo, "commit", "-m", "Record memory decision")
+
+	store := databases.NewMemoryArtifactStore()
+	manager := artifact.CaptureManager{Store: store, Connectors: []artifact.Connector{GitConnector{}}, Timeout: 5 * time.Second}
+	req := artifact.CaptureRequest{TenantID: 7, Hints: map[string]string{"repoPath": repo, "since": "1970-01-01T00:00:00Z"}}
+	first := manager.Capture(ctx, req)
+	second := manager.Capture(ctx, req)
+	if len(first) != 1 || len(second) != 1 {
+		t.Fatalf("expected one artifact each run, got first=%d second=%d", len(first), len(second))
+	}
+	if first[0].ID != second[0].ID || first[0].Kind != artifact.ArtifactGitCommit || first[0].ContentHash == "" {
+		t.Fatalf("expected idempotent commit capture, first=%+v second=%+v", first[0], second[0])
+	}
+}
+
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v failed: %v\n%s", args, err, out)
+	}
+}

--- a/internal/agent/memory/artifact/connectors/tickets.go
+++ b/internal/agent/memory/artifact/connectors/tickets.go
@@ -1,0 +1,18 @@
+package connectors
+
+import (
+	"context"
+
+	"manifold/internal/agent/memory/artifact"
+)
+
+// TicketConnector reserves the ticket capture interface for future integrations.
+type TicketConnector struct{}
+
+// Kind returns the artifact kind captured by this connector.
+func (TicketConnector) Kind() artifact.ArtifactKind { return artifact.ArtifactTicket }
+
+// Capture reports tickets as unavailable until a concrete ticket backend is configured.
+func (TicketConnector) Capture(context.Context, artifact.CaptureRequest) ([]artifact.Artifact, error) {
+	return nil, artifact.ErrConnectorUnavailable
+}

--- a/internal/agent/memory/artifact/connectors/transit.go
+++ b/internal/agent/memory/artifact/connectors/transit.go
@@ -1,0 +1,119 @@
+package connectors
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"manifold/internal/agent/memory/artifact"
+	"manifold/internal/transit"
+)
+
+const defaultTransitCaptureKeyLimit = 32
+
+// TransitConnector captures explicitly referenced Transit memory keys.
+type TransitConnector struct {
+	Store   transit.Store
+	MaxKeys int
+}
+
+// Kind returns the artifact kind captured by this connector.
+func (TransitConnector) Kind() artifact.ArtifactKind { return artifact.ArtifactTransitKey }
+
+// Capture captures explicit Transit keys. Hints: keys, key, transitKeys.
+func (c TransitConnector) Capture(ctx context.Context, req artifact.CaptureRequest) ([]artifact.Artifact, error) {
+	if c.Store == nil {
+		return nil, artifact.ErrConnectorUnavailable
+	}
+	keys := transitKeysFromHints(req.Hints)
+	if len(keys) == 0 {
+		return nil, artifact.ErrConnectorUnavailable
+	}
+	maxKeys := c.MaxKeys
+	if maxKeys <= 0 {
+		maxKeys = defaultTransitCaptureKeyLimit
+	}
+	if len(keys) > maxKeys {
+		keys = keys[:maxKeys]
+	}
+	records, err := c.Store.Get(ctx, req.TenantID, keys)
+	if err != nil {
+		return nil, err
+	}
+	now := time.Now().UTC()
+	out := make([]artifact.Artifact, 0, len(records))
+	for _, record := range records {
+		excerpt := transitExcerpt(record)
+		content := record.KeyName + "\n" + record.Description + "\n" + record.Value + "\n" + strconv.FormatInt(record.Version, 10)
+		hash := sha256.Sum256([]byte(content))
+		authoredAt := record.UpdatedAt
+		if authoredAt.IsZero() {
+			authoredAt = record.CreatedAt
+		}
+		if authoredAt.IsZero() {
+			authoredAt = now
+		}
+		out = append(out, artifact.Artifact{
+			TenantID:    req.TenantID,
+			Kind:        artifact.ArtifactTransitKey,
+			ExternalID:  fmt.Sprintf("%s@v%d", record.KeyName, record.Version),
+			URI:         transitKeyURI(record.KeyName, record.Version),
+			Title:       record.KeyName,
+			Excerpt:     truncateBytes(excerpt, maxArtifactExcerptBytes),
+			ContentHash: fmt.Sprintf("%x", hash),
+			AuthoredBy:  strconv.FormatInt(record.UpdatedBy, 10),
+			AuthoredAt:  authoredAt,
+			CapturedAt:  now,
+			Metadata: map[string]any{
+				"keyName":     record.KeyName,
+				"version":     record.Version,
+				"base64":      record.Base64,
+				"embed":       record.Embed,
+				"embedSource": record.EmbedSource,
+				"createdBy":   record.CreatedBy,
+				"updatedBy":   record.UpdatedBy,
+				"scopeId":     strings.TrimSpace(req.ScopeID),
+				"episodeId":   strings.TrimSpace(req.EpisodeID),
+			},
+		})
+	}
+	return out, nil
+}
+
+func transitKeysFromHints(hints map[string]string) []string {
+	seen := map[string]bool{}
+	out := []string{}
+	for _, name := range []string{"keys", "key", "transitKeys"} {
+		raw := strings.TrimSpace(hints[name])
+		if raw == "" {
+			continue
+		}
+		for _, part := range strings.FieldsFunc(raw, func(r rune) bool {
+			return r == ',' || r == '\n' || r == '\t' || r == ';'
+		}) {
+			key := strings.TrimSpace(part)
+			if key == "" || seen[key] {
+				continue
+			}
+			seen[key] = true
+			out = append(out, key)
+		}
+	}
+	return out
+}
+
+func transitExcerpt(record transit.Record) string {
+	description := strings.TrimSpace(record.Description)
+	if record.Base64 {
+		return strings.TrimSpace(description + "\n\n[base64 value omitted]")
+	}
+	return strings.TrimSpace(description + "\n\n" + record.Value)
+}
+
+func transitKeyURI(key string, version int64) string {
+	return "transit://" + url.PathEscape(key) + "?version=" + strconv.FormatInt(version, 10)
+}

--- a/internal/agent/memory/artifact/service.go
+++ b/internal/agent/memory/artifact/service.go
@@ -1,0 +1,81 @@
+package artifact
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+)
+
+var (
+	// ErrConnectorUnavailable is returned by configured but unavailable connectors.
+	ErrConnectorUnavailable = errors.New("artifact connector unavailable")
+)
+
+// Connector captures artifacts relevant to an episode.
+type Connector interface {
+	Kind() ArtifactKind
+	Capture(ctx context.Context, req CaptureRequest) ([]Artifact, error)
+}
+
+// CaptureRequest identifies the episode/scope and connector-specific hints.
+type CaptureRequest struct {
+	TenantID  int64
+	ScopeID   string
+	EpisodeID string
+	Hints     map[string]string
+}
+
+// CaptureManager fans out episode-end artifact capture without failing the run.
+type CaptureManager struct {
+	Store      Store
+	Connectors []Connector
+	Timeout    time.Duration
+	OnError    func(kind ArtifactKind, err error)
+}
+
+// Capture runs configured connectors and upserts any returned artifacts.
+func (m CaptureManager) Capture(ctx context.Context, req CaptureRequest) []Artifact {
+	if m.Store == nil || len(m.Connectors) == 0 {
+		return nil
+	}
+	timeout := m.Timeout
+	if timeout <= 0 {
+		timeout = 10 * time.Second
+	}
+	var mu sync.Mutex
+	out := []Artifact{}
+	var wg sync.WaitGroup
+	for _, connector := range m.Connectors {
+		if connector == nil {
+			continue
+		}
+		wg.Add(1)
+		go func(c Connector) {
+			defer wg.Done()
+			cctx, cancel := context.WithTimeout(ctx, timeout)
+			defer cancel()
+			items, err := c.Capture(cctx, req)
+			if err != nil {
+				if m.OnError != nil {
+					m.OnError(c.Kind(), err)
+				}
+				return
+			}
+			for _, item := range items {
+				saved, err := m.Store.UpsertArtifact(ctx, item)
+				if err != nil {
+					if m.OnError != nil {
+						m.OnError(c.Kind(), err)
+					}
+					continue
+				}
+				mu.Lock()
+				out = append(out, saved)
+				mu.Unlock()
+			}
+		}(connector)
+	}
+	wg.Wait()
+	return out
+}

--- a/internal/agent/memory/artifact/store.go
+++ b/internal/agent/memory/artifact/store.go
@@ -1,0 +1,29 @@
+package artifact
+
+import "context"
+
+// Store persists immutable captured artifacts.
+type Store interface {
+	Init(ctx context.Context) error
+	UpsertArtifact(ctx context.Context, artifact Artifact) (Artifact, error)
+	GetArtifact(ctx context.Context, tenantID int64, id string) (Artifact, bool, error)
+	FindByExternalID(ctx context.Context, tenantID int64, kind ArtifactKind, externalID string) ([]Artifact, error)
+	SearchArtifacts(ctx context.Context, query SearchQuery) ([]SearchResult, error)
+}
+
+// NoopStore is a disabled artifact store implementation.
+type NoopStore struct{}
+
+func (NoopStore) Init(context.Context) error { return nil }
+func (NoopStore) UpsertArtifact(_ context.Context, artifact Artifact) (Artifact, error) {
+	return artifact, nil
+}
+func (NoopStore) GetArtifact(context.Context, int64, string) (Artifact, bool, error) {
+	return Artifact{}, false, nil
+}
+func (NoopStore) FindByExternalID(context.Context, int64, ArtifactKind, string) ([]Artifact, error) {
+	return nil, nil
+}
+func (NoopStore) SearchArtifacts(context.Context, SearchQuery) ([]SearchResult, error) {
+	return nil, nil
+}

--- a/internal/agent/memory/artifact/types.go
+++ b/internal/agent/memory/artifact/types.go
@@ -1,0 +1,51 @@
+package artifact
+
+import "time"
+
+// ArtifactKind identifies the external system an artifact came from.
+type ArtifactKind string
+
+const (
+	// ArtifactGitCommit records a git commit.
+	ArtifactGitCommit ArtifactKind = "git_commit"
+	// ArtifactGitPR records a pull request.
+	ArtifactGitPR ArtifactKind = "git_pr"
+	// ArtifactChatMessage records a chat message.
+	ArtifactChatMessage ArtifactKind = "chat_message"
+	// ArtifactTicket records an external ticket.
+	ArtifactTicket ArtifactKind = "ticket"
+	// ArtifactDocument records a document.
+	ArtifactDocument ArtifactKind = "document"
+	// ArtifactTransitKey records a transit key version.
+	ArtifactTransitKey ArtifactKind = "transit_key"
+)
+
+// Artifact is an immutable, content-addressed reference to an external object.
+type Artifact struct {
+	ID          string         `json:"id"`
+	TenantID    int64          `json:"tenantId"`
+	Kind        ArtifactKind   `json:"kind"`
+	ExternalID  string         `json:"externalId"`
+	URI         string         `json:"uri"`
+	Title       string         `json:"title"`
+	Excerpt     string         `json:"excerpt"`
+	ContentHash string         `json:"contentHash"`
+	AuthoredBy  string         `json:"authoredBy"`
+	AuthoredAt  time.Time      `json:"authoredAt"`
+	CapturedAt  time.Time      `json:"capturedAt"`
+	Metadata    map[string]any `json:"metadata,omitempty"`
+}
+
+// SearchQuery constrains artifact full-text retrieval.
+type SearchQuery struct {
+	TenantID int64          `json:"tenantId"`
+	Kinds    []ArtifactKind `json:"kinds,omitempty"`
+	Query    string         `json:"query,omitempty"`
+	Limit    int            `json:"limit,omitempty"`
+}
+
+// SearchResult is a scored artifact retrieval result.
+type SearchResult struct {
+	Artifact Artifact `json:"artifact"`
+	Score    float64  `json:"score"`
+}

--- a/internal/agent/memory/belief/events.go
+++ b/internal/agent/memory/belief/events.go
@@ -1,0 +1,33 @@
+package belief
+
+import (
+	"context"
+	"time"
+)
+
+// ChangeKind identifies the belief mutation that downstream systems may react to.
+type ChangeKind string
+
+const (
+	// ChangeStatus marks a status transition such as active to retracted.
+	ChangeStatus ChangeKind = "status"
+	// ChangeConfidence marks a confidence change.
+	ChangeConfidence ChangeKind = "confidence"
+	// ChangeExpiry marks a belief passing its ExpiresAt time.
+	ChangeExpiry ChangeKind = "expiry"
+)
+
+// ChangeEvent describes one belief change observed by a notifying store.
+type ChangeEvent struct {
+	TenantID   int64
+	BeliefID   string
+	Kind       ChangeKind
+	Before     Belief
+	After      Belief
+	OccurredAt time.Time
+}
+
+// ChangeListener receives belief change events asynchronously.
+type ChangeListener interface {
+	OnBeliefChanged(ctx context.Context, ev ChangeEvent)
+}

--- a/internal/agent/memory/belief/notifying_store.go
+++ b/internal/agent/memory/belief/notifying_store.go
@@ -1,0 +1,123 @@
+package belief
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// NotifyingStore decorates a belief store with non-blocking change events.
+type NotifyingStore struct {
+	Store
+
+	queue       chan ChangeEvent
+	listenersMu sync.RWMutex
+	listeners   []ChangeListener
+	dropped     atomic.Uint64
+	closed      chan struct{}
+}
+
+// NewNotifyingStore wraps a belief store. queueSize <= 0 uses a conservative default.
+func NewNotifyingStore(inner Store, queueSize int) *NotifyingStore {
+	if queueSize <= 0 {
+		queueSize = 256
+	}
+	s := &NotifyingStore{
+		Store:  inner,
+		queue:  make(chan ChangeEvent, queueSize),
+		closed: make(chan struct{}),
+	}
+	go s.dispatch()
+	return s
+}
+
+// RegisterListener adds a listener for future belief changes.
+func (s *NotifyingStore) RegisterListener(listener ChangeListener) {
+	if s == nil || listener == nil {
+		return
+	}
+	s.listenersMu.Lock()
+	defer s.listenersMu.Unlock()
+	s.listeners = append(s.listeners, listener)
+}
+
+// DroppedEvents returns how many events were dropped because the queue was full.
+func (s *NotifyingStore) DroppedEvents() uint64 {
+	if s == nil {
+		return 0
+	}
+	return s.dropped.Load()
+}
+
+// Close stops the dispatch worker and closes the wrapped store when it supports Close.
+func (s *NotifyingStore) Close() {
+	if s == nil {
+		return
+	}
+	select {
+	case <-s.closed:
+	default:
+		close(s.closed)
+	}
+	if closer, ok := s.Store.(interface{ Close() }); ok {
+		closer.Close()
+	}
+}
+
+// UpsertBelief delegates the write and emits status/confidence change events.
+func (s *NotifyingStore) UpsertBelief(ctx context.Context, item Belief) (Belief, error) {
+	if s == nil || s.Store == nil {
+		return item, nil
+	}
+	var before Belief
+	var existed bool
+	if item.ID != "" {
+		if got, ok, err := s.Store.GetBelief(ctx, item.TenantID, item.ID); err == nil && ok {
+			before = got
+			existed = true
+		}
+	}
+	after, err := s.Store.UpsertBelief(ctx, item)
+	if err != nil {
+		return Belief{}, err
+	}
+	if !existed || before.ID == "" {
+		return after, nil
+	}
+	now := time.Now().UTC()
+	if before.Status != after.Status {
+		s.emit(ChangeEvent{TenantID: after.TenantID, BeliefID: after.ID, Kind: ChangeStatus, Before: before, After: after, OccurredAt: now})
+	}
+	if before.Confidence != after.Confidence {
+		s.emit(ChangeEvent{TenantID: after.TenantID, BeliefID: after.ID, Kind: ChangeConfidence, Before: before, After: after, OccurredAt: now})
+	}
+	if before.ExpiresAt == nil && after.ExpiresAt != nil && after.ExpiresAt.Before(now) {
+		s.emit(ChangeEvent{TenantID: after.TenantID, BeliefID: after.ID, Kind: ChangeExpiry, Before: before, After: after, OccurredAt: now})
+	}
+	return after, nil
+}
+
+func (s *NotifyingStore) emit(ev ChangeEvent) {
+	select {
+	case s.queue <- ev:
+	default:
+		s.dropped.Add(1)
+	}
+}
+
+func (s *NotifyingStore) dispatch() {
+	for {
+		select {
+		case <-s.closed:
+			return
+		case ev := <-s.queue:
+			s.listenersMu.RLock()
+			listeners := append([]ChangeListener(nil), s.listeners...)
+			s.listenersMu.RUnlock()
+			for _, listener := range listeners {
+				listener.OnBeliefChanged(context.Background(), ev)
+			}
+		}
+	}
+}

--- a/internal/agent/memory/belief/types.go
+++ b/internal/agent/memory/belief/types.go
@@ -78,6 +78,7 @@ const (
 	SourceKindRAGChunk      SourceKind = "rag_chunk"
 	SourceKindTransit       SourceKind = "transit"
 	SourceKindBelief        SourceKind = "belief"
+	SourceKindArtifact      SourceKind = "artifact"
 )
 
 // Scope normalizes the scope hierarchy used by belief memory.

--- a/internal/agent/memory/decision/distiller.go
+++ b/internal/agent/memory/decision/distiller.go
@@ -1,0 +1,133 @@
+package decision
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"manifold/internal/agent/memory/belief"
+)
+
+const (
+	maxCandidateConfidence = 0.90
+)
+
+// EmbedFunc embeds candidate statements for semantic search.
+type EmbedFunc func(ctx context.Context, texts []string) ([][]float32, error)
+
+// ArtifactRef is the bounded artifact context offered to decision distillers.
+type ArtifactRef struct {
+	ID         string `json:"id"`
+	Kind       string `json:"kind"`
+	ExternalID string `json:"externalId,omitempty"`
+	URI        string `json:"uri,omitempty"`
+	Title      string `json:"title,omitempty"`
+	Excerpt    string `json:"excerpt,omitempty"`
+}
+
+// DistillationInput contains the episode envelope for candidate decision extraction.
+type DistillationInput struct {
+	Episode        belief.Episode `json:"episode"`
+	UserRequest    string         `json:"userRequest,omitempty"`
+	FinalAnswer    string         `json:"finalAnswer,omitempty"`
+	Summary        string         `json:"summary,omitempty"`
+	ToolSummary    string         `json:"toolSummary,omitempty"`
+	ReasoningTrace []string       `json:"reasoningTrace,omitempty"`
+	Artifacts      []ArtifactRef  `json:"artifacts,omitempty"`
+}
+
+// Distiller extracts candidate decisions from episode evidence.
+type Distiller interface {
+	Distill(ctx context.Context, input DistillationInput) ([]Candidate, error)
+}
+
+// DistillationResult contains accepted candidates and audit rows.
+type DistillationResult struct {
+	Candidates []Candidate
+	Audit      []Candidate
+	RawPayload string
+}
+
+// AuditDistiller extracts candidates and returns validation audit rows.
+type AuditDistiller interface {
+	DistillWithAudit(ctx context.Context, input DistillationInput) (DistillationResult, error)
+}
+
+// NoopDistiller disables decision extraction.
+type NoopDistiller struct{}
+
+func (NoopDistiller) Distill(context.Context, DistillationInput) ([]Candidate, error) {
+	return nil, nil
+}
+
+// SimpleDistiller records an explicit decision only when the episode text looks decision-like.
+type SimpleDistiller struct {
+	Embed EmbedFunc
+}
+
+// Distill returns at most one conservative candidate from explicit decision language.
+func (d SimpleDistiller) Distill(ctx context.Context, input DistillationInput) ([]Candidate, error) {
+	statement := explicitDecisionStatement(input)
+	if statement == "" {
+		return nil, nil
+	}
+	statement = NormalizeStatement(statement)
+	candidate := Candidate{
+		TenantID:         input.Episode.TenantID,
+		EpisodeID:        input.Episode.ID,
+		ScopeID:          input.Episode.ScopeID,
+		Title:            titleFromStatement(statement),
+		Statement:        statement,
+		StatementHash:    StatementHash(statement),
+		Rationale:        "Extracted from explicit decision language in the episode.",
+		Confidence:       0.55,
+		ReviewState:      ReviewStateNeedsReview,
+		ValidationStatus: CandidateValidationQueued,
+		Model:            "simple",
+		Metadata: map[string]any{
+			"distiller":       "simple",
+			"projectId":       input.Episode.ProjectID,
+			"objectiveId":     input.Episode.ObjectiveID,
+			"agentRole":       input.Episode.AgentRole,
+			"evolvingEntryId": input.Episode.EvolvingEntryID,
+		},
+	}
+	for _, artifact := range input.Artifacts {
+		if strings.TrimSpace(artifact.ID) == "" {
+			continue
+		}
+		candidate.EvidenceHints = append(candidate.EvidenceHints, EvidenceHint{
+			SourceKind: "artifact",
+			SourceID:   artifact.ID,
+			Polarity:   EvidencePolarityFor,
+			Note:       strings.TrimSpace(artifact.Title),
+		})
+	}
+	if d.Embed != nil {
+		if embeddings, err := d.Embed(ctx, []string{statement}); err == nil && len(embeddings) == 1 {
+			candidate.Metadata["embedding"] = "attached"
+		}
+	}
+	return []Candidate{candidate}, nil
+}
+
+func explicitDecisionStatement(input DistillationInput) string {
+	for _, text := range []string{input.FinalAnswer, input.Summary, input.ToolSummary} {
+		for line := range strings.SplitSeq(text, "\n") {
+			line = strings.TrimSpace(strings.TrimLeft(line, "-*0123456789. )\t"))
+			lower := strings.ToLower(line)
+			for _, prefix := range []string{"decision:", "we decided to ", "decided to ", "we chose to ", "chose to ", "adopt "} {
+				if strings.HasPrefix(lower, prefix) {
+					cleaned := strings.TrimSpace(line)
+					if strings.HasPrefix(lower, "decision:") {
+						cleaned = strings.TrimSpace(line[len("decision:"):])
+					}
+					if len([]rune(cleaned)) >= 10 && !strings.HasSuffix(cleaned, "?") {
+						return fmt.Sprintf("We decided to %s", strings.TrimPrefix(cleaned, "we decided to "))
+					}
+				}
+			}
+		}
+	}
+	return ""
+}

--- a/internal/agent/memory/decision/lineage.go
+++ b/internal/agent/memory/decision/lineage.go
@@ -1,0 +1,46 @@
+package decision
+
+import "context"
+
+// Lineage contains the persisted context around a decision.
+type Lineage struct {
+	Decision     Decision           `json:"decision"`
+	Assumptions  []AssumptionLink   `json:"assumptions,omitempty"`
+	Alternatives []Alternative      `json:"alternatives,omitempty"`
+	Evidence     []DecisionEvidence `json:"evidence,omitempty"`
+	Transitions  []Transition       `json:"transitions,omitempty"`
+}
+
+// LoadLineage loads the decision record and its immediate archaeology rows.
+func (s *Service) LoadLineage(ctx context.Context, tenantID int64, id string) (Lineage, bool, error) {
+	if s == nil || s.Store == nil {
+		return Lineage{}, false, ErrStoreRequired
+	}
+	item, ok, err := s.Store.GetDecision(ctx, tenantID, id)
+	if err != nil || !ok {
+		return Lineage{}, ok, err
+	}
+	assumptions, err := s.Store.ListAssumptions(ctx, AssumptionQuery{TenantID: tenantID, DecisionID: id})
+	if err != nil {
+		return Lineage{}, false, err
+	}
+	alternatives, err := s.Store.ListAlternatives(ctx, tenantID, id)
+	if err != nil {
+		return Lineage{}, false, err
+	}
+	evidence, err := s.Store.ListEvidence(ctx, EvidenceQuery{TenantID: tenantID, DecisionID: id})
+	if err != nil {
+		return Lineage{}, false, err
+	}
+	transitions, err := s.Store.ListTransitions(ctx, TransitionQuery{TenantID: tenantID, DecisionID: id})
+	if err != nil {
+		return Lineage{}, false, err
+	}
+	return Lineage{
+		Decision:     item,
+		Assumptions:  assumptions,
+		Alternatives: alternatives,
+		Evidence:     evidence,
+		Transitions:  transitions,
+	}, true, nil
+}

--- a/internal/agent/memory/decision/llm_distiller.go
+++ b/internal/agent/memory/decision/llm_distiller.go
@@ -1,0 +1,249 @@
+package decision
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"manifold/internal/llm"
+)
+
+// LLMDistillerConfig configures LLM-backed decision extraction.
+type LLMDistillerConfig struct {
+	LLM                    llm.Provider
+	Model                  string
+	MaxCandidates          int
+	MinCandidateConfidence float64
+	Embed                  EmbedFunc
+}
+
+// LLMDistiller extracts decision candidates with a strict JSON payload.
+type LLMDistiller struct {
+	Config LLMDistillerConfig
+}
+
+type llmDistillerResponse struct {
+	Candidates []llmCandidatePayload `json:"candidates"`
+}
+
+type llmCandidatePayload struct {
+	Title           string           `json:"title"`
+	Statement       string           `json:"statement"`
+	Rationale       string           `json:"rationale"`
+	Alternatives    []llmAlternative `json:"alternatives"`
+	AssumptionHints []string         `json:"assumption_hints"`
+	EvidenceHints   []EvidenceHint   `json:"evidence_hints"`
+	Confidence      *float64         `json:"confidence"`
+}
+
+type llmAlternative struct {
+	Statement       string `json:"statement"`
+	RejectionReason string `json:"rejection_reason"`
+}
+
+// Distill returns accepted candidates from an LLM extraction result.
+func (d LLMDistiller) Distill(ctx context.Context, input DistillationInput) ([]Candidate, error) {
+	result, err := d.DistillWithAudit(ctx, input)
+	if err != nil {
+		return nil, err
+	}
+	return result.Candidates, nil
+}
+
+// DistillWithAudit returns accepted candidates plus rejected/queued audit rows.
+func (d LLMDistiller) DistillWithAudit(ctx context.Context, input DistillationInput) (DistillationResult, error) {
+	if d.Config.LLM == nil {
+		return DistillationResult{}, nil
+	}
+	maxCandidates := d.Config.MaxCandidates
+	if maxCandidates <= 0 {
+		maxCandidates = 5
+	}
+	bundle, err := json.Marshal(input)
+	if err != nil {
+		return DistillationResult{}, err
+	}
+	msg, err := d.Config.LLM.Chat(ctx, []llm.Message{
+		{Role: "system", Content: llmDecisionDistillerSystemPrompt(maxCandidates)},
+		{Role: "user", Content: string(bundle)},
+	}, nil, d.Config.Model)
+	if err != nil {
+		return DistillationResult{}, err
+	}
+	raw := strings.TrimSpace(msg.Content)
+	parsed, err := parseLLMDecisionResponse(raw)
+	if err != nil {
+		return DistillationResult{
+			Audit: []Candidate{{
+				TenantID:         input.Episode.TenantID,
+				EpisodeID:        input.Episode.ID,
+				ScopeID:          input.Episode.ScopeID,
+				RawPayload:       raw,
+				ReviewState:      ReviewStateNeedsReview,
+				ValidationStatus: CandidateValidationRejected,
+				RejectionReason:  err.Error(),
+				Model:            d.Config.Model,
+				Metadata:         map[string]any{"distiller": "llm"},
+			}},
+			RawPayload: raw,
+		}, nil
+	}
+	result := DistillationResult{RawPayload: raw}
+	for _, payload := range parsed.Candidates {
+		record, candidate, ok := d.validatePayload(input, payload, raw)
+		result.Audit = append(result.Audit, record)
+		if ok {
+			result.Candidates = append(result.Candidates, candidate)
+		}
+	}
+	if d.Config.Embed != nil && len(result.Candidates) > 0 {
+		texts := make([]string, 0, len(result.Candidates))
+		for _, candidate := range result.Candidates {
+			texts = append(texts, candidate.Statement)
+		}
+		if embeddings, err := d.Config.Embed(ctx, texts); err == nil && len(embeddings) == len(result.Candidates) {
+			for i := range result.Candidates {
+				result.Candidates[i].Metadata["embedding"] = "attached"
+			}
+		}
+	}
+	return result, nil
+}
+
+func (d LLMDistiller) validatePayload(input DistillationInput, payload llmCandidatePayload, raw string) (Candidate, Candidate, bool) {
+	record := newCandidate(input, payload, raw, d.Config.Model)
+	reject := func(reason string) (Candidate, Candidate, bool) {
+		record.ValidationStatus = CandidateValidationRejected
+		record.ReviewState = ReviewStateNeedsReview
+		record.RejectionReason = reason
+		return record, Candidate{}, false
+	}
+	statement := NormalizeStatement(payload.Statement)
+	if statement == "" {
+		return reject("statement is required")
+	}
+	if len([]rune(statement)) < 10 {
+		return reject("statement is too short")
+	}
+	if strings.HasSuffix(strings.TrimSpace(payload.Statement), "?") {
+		return reject("statement must not be a question")
+	}
+	if strings.TrimSpace(payload.Rationale) == "" {
+		return reject("rationale is required")
+	}
+	if payload.Confidence == nil || *payload.Confidence < 0 || *payload.Confidence > 1 {
+		return reject("confidence must be between 0 and 1")
+	}
+	confidence := *payload.Confidence
+	if confidence > maxCandidateConfidence {
+		confidence = maxCandidateConfidence
+	}
+	record.Statement = statement
+	record.StatementHash = StatementHash(statement)
+	record.Title = strings.TrimSpace(payload.Title)
+	if record.Title == "" {
+		record.Title = titleFromStatement(statement)
+	}
+	record.Rationale = strings.TrimSpace(payload.Rationale)
+	record.Confidence = confidence
+	record.ValidationStatus = CandidateValidationQueued
+	record.ReviewState = ReviewStateNeedsReview
+	minConfidence := d.Config.MinCandidateConfidence
+	if minConfidence <= 0 {
+		minConfidence = 0.55
+	}
+	if confidence < minConfidence {
+		record.ValidationStatus = CandidateValidationRejected
+		record.RejectionReason = "confidence below minCandidateConfidence"
+		return record, Candidate{}, false
+	}
+	return record, record, true
+}
+
+func newCandidate(input DistillationInput, payload llmCandidatePayload, raw, model string) Candidate {
+	alternatives := make([]Alternative, 0, len(payload.Alternatives))
+	for _, alt := range payload.Alternatives {
+		statement := NormalizeStatement(alt.Statement)
+		if statement == "" {
+			continue
+		}
+		alternatives = append(alternatives, Alternative{
+			TenantID:        input.Episode.TenantID,
+			Statement:       statement,
+			RejectionReason: strings.TrimSpace(alt.RejectionReason),
+		})
+	}
+	return Candidate{
+		TenantID:         input.Episode.TenantID,
+		EpisodeID:        input.Episode.ID,
+		ScopeID:          input.Episode.ScopeID,
+		Title:            strings.TrimSpace(payload.Title),
+		Statement:        NormalizeStatement(payload.Statement),
+		StatementHash:    StatementHash(payload.Statement),
+		Rationale:        strings.TrimSpace(payload.Rationale),
+		Alternatives:     alternatives,
+		AssumptionHints:  trimStrings(payload.AssumptionHints),
+		EvidenceHints:    payload.EvidenceHints,
+		ReviewState:      ReviewStateNeedsReview,
+		ValidationStatus: CandidateValidationQueued,
+		Model:            model,
+		RawPayload:       raw,
+		Metadata: map[string]any{
+			"distiller":       "llm",
+			"projectId":       input.Episode.ProjectID,
+			"objectiveId":     input.Episode.ObjectiveID,
+			"agentRole":       input.Episode.AgentRole,
+			"evolvingEntryId": input.Episode.EvolvingEntryID,
+		},
+	}
+}
+
+func parseLLMDecisionResponse(raw string) (llmDistillerResponse, error) {
+	raw = strings.TrimSpace(raw)
+	if strings.HasPrefix(raw, "```") {
+		raw = strings.TrimPrefix(raw, "```json")
+		raw = strings.TrimPrefix(raw, "```")
+		raw = strings.TrimSuffix(raw, "```")
+		raw = strings.TrimSpace(raw)
+	}
+	if start := strings.Index(raw, "{"); start > 0 {
+		raw = raw[start:]
+	}
+	if end := strings.LastIndex(raw, "}"); end >= 0 && end < len(raw)-1 {
+		raw = raw[:end+1]
+	}
+	var parsed llmDistillerResponse
+	dec := json.NewDecoder(strings.NewReader(raw))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&parsed); err != nil {
+		return llmDistillerResponse{}, fmt.Errorf("invalid decision distiller JSON: %w", err)
+	}
+	return parsed, nil
+}
+
+func trimStrings(values []string) []string {
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			out = append(out, trimmed)
+		}
+	}
+	return out
+}
+
+func llmDecisionDistillerSystemPrompt(maxCandidates int) string {
+	return fmt.Sprintf(`You extract durable project decisions from an agent run.
+Return strict JSON only, with this schema:
+{"candidates":[{"title":"...","statement":"...","rationale":"...","alternatives":[{"statement":"...","rejection_reason":"..."}],"assumption_hints":["..."],"evidence_hints":[{"sourceKind":"episode|human_feedback|tool_result|rag_doc|rag_chunk|transit|belief|artifact","sourceId":"...","polarity":"for|against","note":"..."}],"confidence":0.0}]}
+
+Rules:
+- Emit at most %d candidates.
+- A decision is a choice made among alternatives, not a generic observation.
+- statement must be declarative, at least 10 characters, and not a question.
+- rationale must explain why this choice was made at decision time.
+- Include rejected alternatives only when the run provides evidence.
+- Include assumption_hints as claims the decision depends on.
+- LLM candidates must start in needs_review; do not mark them approved.
+- confidence must be a number between 0 and 1.`, maxCandidates)
+}

--- a/internal/agent/memory/decision/normalize.go
+++ b/internal/agent/memory/decision/normalize.go
@@ -1,0 +1,95 @@
+package decision
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"strings"
+
+	"manifold/internal/agent/memory/belief"
+)
+
+// NormalizeStatement normalizes decision statements with the belief normalizer.
+func NormalizeStatement(statement string) string {
+	return belief.NormalizeStatement(statement)
+}
+
+// StatementHash returns the stable hash used for per-scope decision dedupe.
+func StatementHash(statement string) string {
+	normalized := strings.ToLower(strings.TrimSpace(NormalizeStatement(statement)))
+	digest := sha256.Sum256([]byte(normalized))
+	return fmt.Sprintf("%x", digest)
+}
+
+// NormalizeDecisionStatus returns a safe default for blank or invalid statuses.
+func NormalizeDecisionStatus(status DecisionStatus) DecisionStatus {
+	switch DecisionStatus(strings.ToLower(strings.TrimSpace(string(status)))) {
+	case DecisionStatusProposed:
+		return DecisionStatusProposed
+	case DecisionStatusStale:
+		return DecisionStatusStale
+	case DecisionStatusSuperseded:
+		return DecisionStatusSuperseded
+	case DecisionStatusRevoked:
+		return DecisionStatusRevoked
+	default:
+		return DecisionStatusActive
+	}
+}
+
+// NormalizeReviewState returns a safe default for blank or invalid review states.
+func NormalizeReviewState(state ReviewState) ReviewState {
+	switch ReviewState(strings.ToLower(strings.TrimSpace(string(state)))) {
+	case ReviewStateNeedsReview:
+		return ReviewStateNeedsReview
+	case ReviewStateOperatorApproved:
+		return ReviewStateOperatorApproved
+	case ReviewStateOperatorRejected:
+		return ReviewStateOperatorRejected
+	default:
+		return ReviewStateAutoActive
+	}
+}
+
+// NormalizeCandidateValidationStatus returns a safe default for candidate validation status.
+func NormalizeCandidateValidationStatus(status CandidateValidationStatus) CandidateValidationStatus {
+	switch CandidateValidationStatus(strings.ToLower(strings.TrimSpace(string(status)))) {
+	case CandidateValidationQueued:
+		return CandidateValidationQueued
+	case CandidateValidationRejected:
+		return CandidateValidationRejected
+	default:
+		return CandidateValidationAccepted
+	}
+}
+
+// NormalizeEvidencePolarity returns "for" unless an explicit opposing polarity is present.
+func NormalizeEvidencePolarity(polarity EvidencePolarity) EvidencePolarity {
+	switch EvidencePolarity(strings.ToLower(strings.TrimSpace(string(polarity)))) {
+	case EvidencePolarityAgainst:
+		return EvidencePolarityAgainst
+	default:
+		return EvidencePolarityFor
+	}
+}
+
+// NormalizeAssumptionCriticality returns contextual for blank or invalid criticality.
+func NormalizeAssumptionCriticality(criticality AssumptionCriticality) AssumptionCriticality {
+	switch AssumptionCriticality(strings.ToLower(strings.TrimSpace(string(criticality)))) {
+	case CriticalityLoadBearing:
+		return CriticalityLoadBearing
+	case CriticalitySupporting:
+		return CriticalitySupporting
+	default:
+		return CriticalityContextual
+	}
+}
+
+func clampConfidence(value float64) float64 {
+	if value < 0 {
+		return 0
+	}
+	if value > 1 {
+		return 1
+	}
+	return value
+}

--- a/internal/agent/memory/decision/reactor.go
+++ b/internal/agent/memory/decision/reactor.go
@@ -1,0 +1,116 @@
+package decision
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"manifold/internal/agent/memory/belief"
+)
+
+// Reactor reacts to belief changes by flagging dependent decisions.
+type Reactor struct {
+	Decisions *Service
+	Beliefs   belief.Store
+	Config    ReactorConfig
+}
+
+// ReactorConfig tunes confidence-based decision reactivity.
+type ReactorConfig struct {
+	ConfidenceFloor     float64
+	ConfidenceDropDelta float64
+}
+
+// OnBeliefChanged handles one belief change event.
+func (r *Reactor) OnBeliefChanged(ctx context.Context, ev belief.ChangeEvent) {
+	if r == nil || r.Decisions == nil || r.Decisions.Store == nil {
+		return
+	}
+	links, err := r.Decisions.Store.ListAssumptions(ctx, AssumptionQuery{TenantID: ev.TenantID, BeliefID: ev.BeliefID})
+	if err != nil {
+		return
+	}
+	for _, link := range links {
+		r.reactToLink(ctx, ev, link)
+	}
+}
+
+func (r *Reactor) reactToLink(ctx context.Context, ev belief.ChangeEvent, link AssumptionLink) {
+	criticality := NormalizeAssumptionCriticality(link.Criticality)
+	switch ev.Kind {
+	case belief.ChangeStatus:
+		if ev.After.Status == belief.BeliefStatusRetracted || ev.After.Status == belief.BeliefStatusSuperseded {
+			switch criticality {
+			case CriticalityLoadBearing:
+				r.markStale(ctx, ev, link, fmt.Sprintf("Load-bearing belief changed from %s to %s: %s", ev.Before.Status, ev.After.Status, link.BeliefStatementAtLink))
+			case CriticalitySupporting:
+				r.needsReview(ctx, ev, link, fmt.Sprintf("Supporting belief changed from %s to %s: %s", ev.Before.Status, ev.After.Status, link.BeliefStatementAtLink))
+			default:
+				r.auditOnly(ctx, ev, link, fmt.Sprintf("Contextual belief changed from %s to %s", ev.Before.Status, ev.After.Status))
+			}
+		}
+	case belief.ChangeExpiry:
+		switch criticality {
+		case CriticalityLoadBearing:
+			r.markStale(ctx, ev, link, "Load-bearing belief expired: "+link.BeliefStatementAtLink)
+		case CriticalitySupporting:
+			r.needsReview(ctx, ev, link, "Supporting belief expired: "+link.BeliefStatementAtLink)
+		default:
+			r.auditOnly(ctx, ev, link, "Contextual belief expired")
+		}
+	case belief.ChangeConfidence:
+		if r.confidenceChangedEnough(ev.After.Confidence, link.BeliefConfidenceAtLink) {
+			switch criticality {
+			case CriticalityLoadBearing:
+				r.needsReview(ctx, ev, link, fmt.Sprintf("Load-bearing belief confidence changed from %.2f to %.2f: %s", link.BeliefConfidenceAtLink, ev.After.Confidence, link.BeliefStatementAtLink))
+			case CriticalitySupporting:
+				r.auditOnly(ctx, ev, link, fmt.Sprintf("Supporting belief confidence changed from %.2f to %.2f", link.BeliefConfidenceAtLink, ev.After.Confidence))
+			}
+		}
+	}
+}
+
+func (r *Reactor) confidenceChangedEnough(current, snapshot float64) bool {
+	floor := r.Config.ConfidenceFloor
+	if floor <= 0 {
+		floor = 0.35
+	}
+	delta := r.Config.ConfidenceDropDelta
+	if delta <= 0 {
+		delta = 0.30
+	}
+	return current < floor || snapshot-current >= delta
+}
+
+func (r *Reactor) markStale(ctx context.Context, ev belief.ChangeEvent, link AssumptionLink, reason string) {
+	item, ok, err := r.Decisions.Store.GetDecision(ctx, ev.TenantID, link.DecisionID)
+	if err != nil || !ok || item.Status == DecisionStatusStale || item.Status == DecisionStatusSuperseded || item.Status == DecisionStatusRevoked {
+		return
+	}
+	_, _ = r.Decisions.TransitionDecision(ctx, ev.TenantID, link.DecisionID, DecisionStatusStale, TransitionRequest{
+		Reason:      strings.TrimSpace(reason),
+		TriggerKind: TriggerBeliefChange,
+		TriggerID:   ev.BeliefID,
+		ReviewState: ReviewStateNeedsReview,
+	})
+}
+
+func (r *Reactor) needsReview(ctx context.Context, ev belief.ChangeEvent, link AssumptionLink, reason string) {
+	_, _ = r.Decisions.MarkNeedsReview(ctx, ev.TenantID, link.DecisionID, strings.TrimSpace(reason), ev.BeliefID)
+}
+
+func (r *Reactor) auditOnly(ctx context.Context, ev belief.ChangeEvent, link AssumptionLink, reason string) {
+	item, ok, err := r.Decisions.Store.GetDecision(ctx, ev.TenantID, link.DecisionID)
+	if err != nil || !ok {
+		return
+	}
+	_, _ = r.Decisions.Store.RecordTransition(ctx, Transition{
+		TenantID:    ev.TenantID,
+		DecisionID:  link.DecisionID,
+		FromStatus:  item.Status,
+		ToStatus:    item.Status,
+		Reason:      strings.TrimSpace(reason),
+		TriggerKind: TriggerBeliefChange,
+		TriggerID:   ev.BeliefID,
+	})
+}

--- a/internal/agent/memory/decision/reactor_test.go
+++ b/internal/agent/memory/decision/reactor_test.go
@@ -1,0 +1,77 @@
+package decision_test
+
+import (
+	"context"
+	"testing"
+
+	"manifold/internal/agent/memory/belief"
+	. "manifold/internal/agent/memory/decision"
+	"manifold/internal/persistence/databases"
+)
+
+func TestReactorMarksLoadBearingDecisionStale(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	store := databases.NewMemoryDecisionStore()
+	service := &Service{Store: store}
+	item, err := service.CreateDecision(ctx, Decision{TenantID: 7, ScopeID: "scope", Statement: "Use pgvector for memory search.", Status: DecisionStatusActive})
+	if err != nil {
+		t.Fatalf("CreateDecision: %v", err)
+	}
+	_, err = store.AddAssumption(ctx, AssumptionLink{
+		TenantID:               7,
+		DecisionID:             item.ID,
+		BeliefID:               "belief-1",
+		Criticality:            CriticalityLoadBearing,
+		BeliefStatementAtLink:  "Postgres is available.",
+		BeliefConfidenceAtLink: 0.9,
+	})
+	if err != nil {
+		t.Fatalf("AddAssumption: %v", err)
+	}
+	reactor := Reactor{Decisions: service}
+	reactor.OnBeliefChanged(ctx, belief.ChangeEvent{
+		TenantID: 7,
+		BeliefID: "belief-1",
+		Kind:     belief.ChangeStatus,
+		Before:   belief.Belief{Status: belief.BeliefStatusActive},
+		After:    belief.Belief{Status: belief.BeliefStatusRetracted},
+	})
+	got, _, err := store.GetDecision(ctx, 7, item.ID)
+	if err != nil {
+		t.Fatalf("GetDecision: %v", err)
+	}
+	if got.Status != DecisionStatusStale || got.ReviewState != ReviewStateNeedsReview || got.StaleReason == "" {
+		t.Fatalf("expected stale decision with reason, got %+v", got)
+	}
+}
+
+func TestReactorFlagsSupportingDecisionForReview(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	store := databases.NewMemoryDecisionStore()
+	service := &Service{Store: store}
+	item, err := service.CreateDecision(ctx, Decision{TenantID: 7, ScopeID: "scope", Statement: "Use pgvector for memory search.", Status: DecisionStatusActive})
+	if err != nil {
+		t.Fatalf("CreateDecision: %v", err)
+	}
+	_, err = store.AddAssumption(ctx, AssumptionLink{TenantID: 7, DecisionID: item.ID, BeliefID: "belief-1", Criticality: CriticalitySupporting, BeliefStatementAtLink: "Postgres is available.", BeliefConfidenceAtLink: 0.9})
+	if err != nil {
+		t.Fatalf("AddAssumption: %v", err)
+	}
+	reactor := Reactor{Decisions: service}
+	reactor.OnBeliefChanged(ctx, belief.ChangeEvent{
+		TenantID: 7,
+		BeliefID: "belief-1",
+		Kind:     belief.ChangeStatus,
+		Before:   belief.Belief{Status: belief.BeliefStatusActive},
+		After:    belief.Belief{Status: belief.BeliefStatusSuperseded},
+	})
+	got, _, err := store.GetDecision(ctx, 7, item.ID)
+	if err != nil {
+		t.Fatalf("GetDecision: %v", err)
+	}
+	if got.Status != DecisionStatusActive || got.ReviewState != ReviewStateNeedsReview {
+		t.Fatalf("expected active decision flagged for review, got %+v", got)
+	}
+}

--- a/internal/agent/memory/decision/service.go
+++ b/internal/agent/memory/decision/service.go
@@ -1,0 +1,413 @@
+package decision
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"maps"
+	"strings"
+	"time"
+
+	"manifold/internal/agent/memory/belief"
+
+	"github.com/google/uuid"
+)
+
+var (
+	// ErrStoreRequired is returned when a service method needs a backing store.
+	ErrStoreRequired = errors.New("decision store is required")
+	// ErrInvalidTransition is returned for illegal lifecycle transitions.
+	ErrInvalidTransition = errors.New("invalid decision transition")
+)
+
+// Service enforces decision lifecycle invariants above the persistence layer.
+type Service struct {
+	Store  Store
+	Belief belief.Store
+	Config ServiceConfig
+}
+
+// ServiceConfig tunes decision candidate acceptance.
+type ServiceConfig struct {
+	AssumptionSimilarityFloor float64
+	AutoActivateCandidates    bool
+}
+
+// CreateDecision normalizes and persists a decision.
+func (s *Service) CreateDecision(ctx context.Context, d Decision) (Decision, error) {
+	if s == nil || s.Store == nil {
+		return Decision{}, ErrStoreRequired
+	}
+	d = normalizeDecision(d)
+	existing, ok, err := findExistingDecision(ctx, s.Store, d)
+	if err != nil {
+		return Decision{}, err
+	}
+	if ok && strings.TrimSpace(d.ID) == "" {
+		d.ID = existing.ID
+		d.CreatedAt = existing.CreatedAt
+	}
+	created, err := s.Store.UpsertDecision(ctx, d)
+	if err != nil {
+		return Decision{}, err
+	}
+	if !ok {
+		_, err = s.Store.RecordTransition(ctx, Transition{
+			TenantID:    created.TenantID,
+			DecisionID:  created.ID,
+			FromStatus:  "",
+			ToStatus:    created.Status,
+			Reason:      "decision recorded",
+			TriggerKind: TriggerDistiller,
+			TriggerID:   created.EpisodeID,
+		})
+	}
+	return created, err
+}
+
+// TransitionDecision changes a decision status and appends an audit transition.
+func (s *Service) TransitionDecision(ctx context.Context, tenantID int64, id string, to DecisionStatus, req TransitionRequest) (Decision, error) {
+	if s == nil || s.Store == nil {
+		return Decision{}, ErrStoreRequired
+	}
+	item, ok, err := s.Store.GetDecision(ctx, tenantID, strings.TrimSpace(id))
+	if err != nil {
+		return Decision{}, err
+	}
+	if !ok {
+		return Decision{}, fmt.Errorf("decision not found: %s", id)
+	}
+	to = NormalizeDecisionStatus(to)
+	trigger := req.TriggerKind
+	if trigger == "" {
+		trigger = TriggerOperator
+	}
+	if !validTransition(item.Status, to, trigger) {
+		return Decision{}, fmt.Errorf("%w: %s -> %s", ErrInvalidTransition, item.Status, to)
+	}
+	if item.Status == to && trigger != TriggerBeliefChange {
+		return item, nil
+	}
+	from := item.Status
+	item.Status = to
+	if req.ReviewState != "" {
+		item.ReviewState = NormalizeReviewState(req.ReviewState)
+	}
+	if to == DecisionStatusStale {
+		item.StaleReason = strings.TrimSpace(req.Reason)
+	}
+	if to != DecisionStatusStale && req.ClearStaleReason {
+		item.StaleReason = ""
+	}
+	if req.SupersededBy != "" {
+		item.SupersededBy = strings.TrimSpace(req.SupersededBy)
+	}
+	item, err = s.Store.UpsertDecision(ctx, item)
+	if err != nil {
+		return Decision{}, err
+	}
+	_, err = s.Store.RecordTransition(ctx, Transition{
+		TenantID:    item.TenantID,
+		DecisionID:  item.ID,
+		FromStatus:  from,
+		ToStatus:    to,
+		Reason:      strings.TrimSpace(req.Reason),
+		TriggerKind: trigger,
+		TriggerID:   strings.TrimSpace(req.TriggerID),
+		ActorUserID: req.ActorUserID,
+	})
+	return item, err
+}
+
+// TransitionRequest carries transition audit metadata.
+type TransitionRequest struct {
+	Reason           string
+	TriggerKind      TransitionTriggerKind
+	TriggerID        string
+	ActorUserID      *int64
+	ReviewState      ReviewState
+	SupersededBy     string
+	ClearStaleReason bool
+}
+
+// MarkNeedsReview flags an active decision without changing status.
+func (s *Service) MarkNeedsReview(ctx context.Context, tenantID int64, id, reason, triggerID string) (Decision, error) {
+	if s == nil || s.Store == nil {
+		return Decision{}, ErrStoreRequired
+	}
+	item, ok, err := s.Store.GetDecision(ctx, tenantID, strings.TrimSpace(id))
+	if err != nil {
+		return Decision{}, err
+	}
+	if !ok {
+		return Decision{}, fmt.Errorf("decision not found: %s", id)
+	}
+	if item.ReviewState == ReviewStateNeedsReview {
+		return item, nil
+	}
+	return s.TransitionDecision(ctx, tenantID, id, item.Status, TransitionRequest{
+		Reason:      reason,
+		TriggerKind: TriggerBeliefChange,
+		TriggerID:   triggerID,
+		ReviewState: ReviewStateNeedsReview,
+	})
+}
+
+// ReaffirmDecision moves a stale decision back to active with an operator audit row.
+func (s *Service) ReaffirmDecision(ctx context.Context, tenantID int64, id, reason string, actorUserID *int64) (Decision, error) {
+	return s.TransitionDecision(ctx, tenantID, id, DecisionStatusActive, TransitionRequest{
+		Reason:           reason,
+		TriggerKind:      TriggerOperator,
+		ActorUserID:      actorUserID,
+		ReviewState:      ReviewStateOperatorApproved,
+		ClearStaleReason: true,
+	})
+}
+
+// RevokeDecision revokes a proposed, active, or stale decision.
+func (s *Service) RevokeDecision(ctx context.Context, tenantID int64, id, reason string, actorUserID *int64) (Decision, error) {
+	return s.TransitionDecision(ctx, tenantID, id, DecisionStatusRevoked, TransitionRequest{
+		Reason:      reason,
+		TriggerKind: TriggerOperator,
+		ActorUserID: actorUserID,
+	})
+}
+
+// Supersede marks an old decision superseded by a new active or proposed decision.
+func (s *Service) Supersede(ctx context.Context, tenantID int64, oldID string, replacement Decision, reason string, actorUserID *int64) (Decision, Decision, error) {
+	if s == nil || s.Store == nil {
+		return Decision{}, Decision{}, ErrStoreRequired
+	}
+	replacement.Status = NormalizeDecisionStatus(replacement.Status)
+	if replacement.Status != DecisionStatusActive && replacement.Status != DecisionStatusProposed {
+		return Decision{}, Decision{}, fmt.Errorf("replacement decision must be active or proposed")
+	}
+	replacement.TenantID = tenantID
+	replacement, err := s.CreateDecision(ctx, replacement)
+	if err != nil {
+		return Decision{}, Decision{}, err
+	}
+	old, err := s.TransitionDecision(ctx, tenantID, oldID, DecisionStatusSuperseded, TransitionRequest{
+		Reason:       reason,
+		TriggerKind:  TriggerSupersession,
+		TriggerID:    replacement.ID,
+		ActorUserID:  actorUserID,
+		SupersededBy: replacement.ID,
+	})
+	if err != nil {
+		return Decision{}, Decision{}, err
+	}
+	return old, replacement, nil
+}
+
+// AcceptCandidate persists a candidate as an active decision and resolves assumptions.
+func (s *Service) AcceptCandidate(ctx context.Context, tenantID int64, candidateID string, actorUserID *int64) (Decision, error) {
+	if s == nil || s.Store == nil {
+		return Decision{}, ErrStoreRequired
+	}
+	candidate, ok, err := s.Store.GetCandidate(ctx, tenantID, strings.TrimSpace(candidateID))
+	if err != nil {
+		return Decision{}, err
+	}
+	if !ok {
+		return Decision{}, fmt.Errorf("candidate not found: %s", candidateID)
+	}
+	status := DecisionStatusActive
+	review := ReviewStateOperatorApproved
+	if s.Config.AutoActivateCandidates && actorUserID == nil {
+		review = ReviewStateAutoActive
+	}
+	created, err := s.CreateDecision(ctx, Decision{
+		TenantID:      candidate.TenantID,
+		ScopeID:       candidate.ScopeID,
+		EpisodeID:     candidate.EpisodeID,
+		Title:         candidate.Title,
+		Statement:     candidate.Statement,
+		StatementHash: candidate.StatementHash,
+		Rationale:     candidate.Rationale,
+		DecidedBy:     decidedBy(actorUserID),
+		DecidedAt:     time.Now().UTC(),
+		Status:        status,
+		ReviewState:   review,
+		Confidence:    candidate.Confidence,
+		Metadata:      maps.Clone(candidate.Metadata),
+	})
+	if err != nil {
+		return Decision{}, err
+	}
+	unresolved := make([]string, 0)
+	for _, hint := range candidate.AssumptionHints {
+		link, ok, err := s.resolveAssumptionHint(ctx, created, hint)
+		if err != nil {
+			return Decision{}, err
+		}
+		if !ok {
+			unresolved = append(unresolved, strings.TrimSpace(hint))
+			continue
+		}
+		if _, err := s.Store.AddAssumption(ctx, link); err != nil {
+			return Decision{}, err
+		}
+	}
+	for _, alt := range candidate.Alternatives {
+		alt.TenantID = created.TenantID
+		alt.DecisionID = created.ID
+		if _, err := s.Store.AddAlternative(ctx, alt); err != nil {
+			return Decision{}, err
+		}
+	}
+	for _, hint := range candidate.EvidenceHints {
+		if strings.TrimSpace(hint.SourceKind) == "" || strings.TrimSpace(hint.SourceID) == "" {
+			continue
+		}
+		if _, err := s.Store.AddEvidence(ctx, DecisionEvidence{
+			TenantID:   created.TenantID,
+			DecisionID: created.ID,
+			SourceKind: strings.TrimSpace(hint.SourceKind),
+			SourceID:   strings.TrimSpace(hint.SourceID),
+			Polarity:   NormalizeEvidencePolarity(hint.Polarity),
+			Weight:     candidate.Confidence,
+			Note:       strings.TrimSpace(hint.Note),
+		}); err != nil {
+			return Decision{}, err
+		}
+	}
+	if len(unresolved) > 0 {
+		if created.Metadata == nil {
+			created.Metadata = map[string]any{}
+		}
+		created.Metadata["unresolvedAssumptions"] = unresolved
+		created, err = s.Store.UpsertDecision(ctx, created)
+		if err != nil {
+			return Decision{}, err
+		}
+	}
+	candidate.ValidationStatus = CandidateValidationAccepted
+	candidate.AcceptedDecisionID = created.ID
+	candidate.ReviewState = review
+	_, err = s.Store.RecordCandidate(ctx, candidate)
+	return created, err
+}
+
+func (s *Service) resolveAssumptionHint(ctx context.Context, d Decision, hint string) (AssumptionLink, bool, error) {
+	hint = strings.TrimSpace(hint)
+	if hint == "" || s.Belief == nil {
+		return AssumptionLink{}, false, nil
+	}
+	floor := s.Config.AssumptionSimilarityFloor
+	if floor <= 0 {
+		floor = 0.80
+	}
+	results, err := s.Belief.SearchBeliefs(ctx, belief.SearchQuery{
+		TenantID: d.TenantID,
+		ScopeIDs: []string{d.ScopeID},
+		Query:    hint,
+		Statuses: []belief.BeliefStatus{belief.BeliefStatusActive},
+		Limit:    1,
+	})
+	if err != nil {
+		return AssumptionLink{}, false, err
+	}
+	if len(results) == 0 || results[0].Score < floor {
+		return AssumptionLink{}, false, nil
+	}
+	item := results[0].Belief
+	return AssumptionLink{
+		TenantID:               d.TenantID,
+		DecisionID:             d.ID,
+		BeliefID:               item.ID,
+		Criticality:            CriticalitySupporting,
+		BeliefStatementAtLink:  item.Statement,
+		BeliefConfidenceAtLink: item.Confidence,
+		Note:                   hint,
+	}, true, nil
+}
+
+func normalizeDecision(d Decision) Decision {
+	now := time.Now().UTC()
+	if strings.TrimSpace(d.ID) == "" {
+		d.ID = uuid.NewString()
+	}
+	d.Statement = NormalizeStatement(d.Statement)
+	if strings.TrimSpace(d.StatementHash) == "" {
+		d.StatementHash = StatementHash(d.Statement)
+	}
+	d.Title = strings.TrimSpace(d.Title)
+	if d.Title == "" {
+		d.Title = titleFromStatement(d.Statement)
+	}
+	d.Status = NormalizeDecisionStatus(d.Status)
+	d.ReviewState = NormalizeReviewState(d.ReviewState)
+	d.Confidence = clampConfidence(d.Confidence)
+	if d.DecidedAt.IsZero() {
+		d.DecidedAt = now
+	}
+	if d.CreatedAt.IsZero() {
+		d.CreatedAt = now
+	}
+	d.UpdatedAt = now
+	if d.Metadata == nil {
+		d.Metadata = map[string]any{}
+	}
+	return d
+}
+
+func titleFromStatement(statement string) string {
+	statement = strings.TrimSpace(statement)
+	if statement == "" {
+		return "Untitled decision"
+	}
+	if len([]rune(statement)) <= 96 {
+		return strings.TrimSuffix(statement, ".")
+	}
+	runes := []rune(statement)
+	return strings.TrimSpace(string(runes[:96])) + "..."
+}
+
+func findExistingDecision(ctx context.Context, store Store, d Decision) (Decision, bool, error) {
+	if strings.TrimSpace(d.ScopeID) == "" || strings.TrimSpace(d.StatementHash) == "" {
+		return Decision{}, false, nil
+	}
+	results, err := store.SearchDecisions(ctx, SearchQuery{
+		TenantID: d.TenantID,
+		ScopeIDs: []string{d.ScopeID},
+		Query:    d.Statement,
+		Statuses: []DecisionStatus{DecisionStatusProposed, DecisionStatusActive, DecisionStatusStale, DecisionStatusSuperseded, DecisionStatusRevoked},
+		Limit:    20,
+	})
+	if err != nil {
+		return Decision{}, false, err
+	}
+	for _, result := range results {
+		if result.Decision.StatementHash == d.StatementHash {
+			return result.Decision, true, nil
+		}
+	}
+	return Decision{}, false, nil
+}
+
+func validTransition(from, to DecisionStatus, trigger TransitionTriggerKind) bool {
+	if from == "" {
+		return true
+	}
+	if from == to {
+		return trigger == TriggerBeliefChange
+	}
+	switch NormalizeDecisionStatus(from) {
+	case DecisionStatusProposed:
+		return to == DecisionStatusActive || to == DecisionStatusRevoked
+	case DecisionStatusActive:
+		return to == DecisionStatusStale || to == DecisionStatusSuperseded || to == DecisionStatusRevoked
+	case DecisionStatusStale:
+		return to == DecisionStatusActive || to == DecisionStatusSuperseded || to == DecisionStatusRevoked
+	default:
+		return false
+	}
+}
+
+func decidedBy(actorUserID *int64) string {
+	if actorUserID == nil {
+		return "agent:decision_distiller"
+	}
+	return fmt.Sprintf("human:%d", *actorUserID)
+}

--- a/internal/agent/memory/decision/service_test.go
+++ b/internal/agent/memory/decision/service_test.go
@@ -1,0 +1,128 @@
+package decision_test
+
+import (
+	"context"
+	"testing"
+
+	"manifold/internal/agent/memory/belief"
+	. "manifold/internal/agent/memory/decision"
+	"manifold/internal/persistence/databases"
+)
+
+func TestServiceTransitionMatrix(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	cases := []struct {
+		name string
+		from DecisionStatus
+		to   DecisionStatus
+		ok   bool
+	}{
+		{"proposed active", DecisionStatusProposed, DecisionStatusActive, true},
+		{"proposed revoked", DecisionStatusProposed, DecisionStatusRevoked, true},
+		{"proposed stale", DecisionStatusProposed, DecisionStatusStale, false},
+		{"active stale", DecisionStatusActive, DecisionStatusStale, true},
+		{"active superseded", DecisionStatusActive, DecisionStatusSuperseded, true},
+		{"active revoked", DecisionStatusActive, DecisionStatusRevoked, true},
+		{"stale active", DecisionStatusStale, DecisionStatusActive, true},
+		{"stale superseded", DecisionStatusStale, DecisionStatusSuperseded, true},
+		{"superseded active", DecisionStatusSuperseded, DecisionStatusActive, false},
+		{"revoked active", DecisionStatusRevoked, DecisionStatusActive, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			store := databases.NewMemoryDecisionStore()
+			service := Service{Store: store}
+			item, err := service.CreateDecision(ctx, Decision{
+				TenantID:  7,
+				ScopeID:   "scope",
+				Statement: "Use pgvector for memory retrieval.",
+				Status:    tc.from,
+			})
+			if err != nil {
+				t.Fatalf("CreateDecision: %v", err)
+			}
+			_, err = service.TransitionDecision(ctx, 7, item.ID, tc.to, TransitionRequest{Reason: "test"})
+			if tc.ok && err != nil {
+				t.Fatalf("expected transition to succeed: %v", err)
+			}
+			if !tc.ok && err == nil {
+				t.Fatal("expected transition to fail")
+			}
+		})
+	}
+}
+
+func TestServiceSupersedeLinksOldDecision(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	store := databases.NewMemoryDecisionStore()
+	service := Service{Store: store}
+	old, err := service.CreateDecision(ctx, Decision{TenantID: 7, ScopeID: "scope", Statement: "Use sqlite for memory retrieval.", Status: DecisionStatusActive})
+	if err != nil {
+		t.Fatalf("CreateDecision: %v", err)
+	}
+	updated, replacement, err := service.Supersede(ctx, 7, old.ID, Decision{ScopeID: "scope", Statement: "Use pgvector for memory retrieval.", Status: DecisionStatusActive}, "better hybrid search", nil)
+	if err != nil {
+		t.Fatalf("Supersede: %v", err)
+	}
+	if updated.Status != DecisionStatusSuperseded || updated.SupersededBy != replacement.ID {
+		t.Fatalf("old decision not superseded correctly: %+v replacement=%+v", updated, replacement)
+	}
+	transitions, err := store.ListTransitions(ctx, TransitionQuery{TenantID: 7, DecisionID: old.ID})
+	if err != nil {
+		t.Fatalf("ListTransitions: %v", err)
+	}
+	if len(transitions) < 2 || transitions[len(transitions)-1].TriggerKind != TriggerSupersession {
+		t.Fatalf("expected supersession audit row, got %+v", transitions)
+	}
+}
+
+func TestAcceptCandidateResolvesAssumptionHints(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	decisionStore := databases.NewMemoryDecisionStore()
+	beliefStore := databases.NewMemoryBeliefStore()
+	scope, err := beliefStore.EnsureScope(ctx, belief.Scope{TenantID: 7, Kind: belief.ScopeKindProject, Path: "project", Label: "project"})
+	if err != nil {
+		t.Fatalf("EnsureScope: %v", err)
+	}
+	seed, err := beliefStore.UpsertBelief(ctx, belief.Belief{
+		TenantID:      7,
+		ScopeID:       scope.ID,
+		Statement:     "Postgres is already available for memory storage.",
+		StatementHash: belief.StatementHash("Postgres is already available for memory storage."),
+		Confidence:    0.95,
+		Status:        belief.BeliefStatusActive,
+	})
+	if err != nil {
+		t.Fatalf("UpsertBelief: %v", err)
+	}
+	candidate, err := decisionStore.RecordCandidate(ctx, Candidate{
+		TenantID:         7,
+		EpisodeID:        "episode",
+		ScopeID:          scope.ID,
+		Statement:        "Use pgvector for memory retrieval.",
+		Rationale:        "It keeps vector search near Postgres-backed memory.",
+		Confidence:       0.8,
+		ReviewState:      ReviewStateNeedsReview,
+		ValidationStatus: CandidateValidationQueued,
+		AssumptionHints:  []string{"Postgres"},
+	})
+	if err != nil {
+		t.Fatalf("RecordCandidate: %v", err)
+	}
+	service := Service{Store: decisionStore, Belief: beliefStore, Config: ServiceConfig{AssumptionSimilarityFloor: 0.1}}
+	accepted, err := service.AcceptCandidate(ctx, 7, candidate.ID, nil)
+	if err != nil {
+		t.Fatalf("AcceptCandidate: %v", err)
+	}
+	links, err := decisionStore.ListAssumptions(ctx, AssumptionQuery{TenantID: 7, DecisionID: accepted.ID})
+	if err != nil {
+		t.Fatalf("ListAssumptions: %v", err)
+	}
+	if len(links) != 1 || links[0].BeliefID != seed.ID || links[0].BeliefStatementAtLink == "" {
+		t.Fatalf("unexpected assumption links: %+v", links)
+	}
+}

--- a/internal/agent/memory/decision/store.go
+++ b/internal/agent/memory/decision/store.go
@@ -1,0 +1,69 @@
+package decision
+
+import "context"
+
+// Store persists decisions, assumptions, alternatives, evidence, transitions, and candidates.
+type Store interface {
+	Init(ctx context.Context) error
+	UpsertDecision(ctx context.Context, d Decision) (Decision, error)
+	GetDecision(ctx context.Context, tenantID int64, id string) (Decision, bool, error)
+	SearchDecisions(ctx context.Context, q SearchQuery) ([]SearchResult, error)
+	AddAssumption(ctx context.Context, a AssumptionLink) (AssumptionLink, error)
+	ListAssumptions(ctx context.Context, q AssumptionQuery) ([]AssumptionLink, error)
+	AddAlternative(ctx context.Context, alt Alternative) (Alternative, error)
+	ListAlternatives(ctx context.Context, tenantID int64, decisionID string) ([]Alternative, error)
+	AddEvidence(ctx context.Context, e DecisionEvidence) (DecisionEvidence, error)
+	ListEvidence(ctx context.Context, q EvidenceQuery) ([]DecisionEvidence, error)
+	RecordTransition(ctx context.Context, t Transition) (Transition, error)
+	ListTransitions(ctx context.Context, q TransitionQuery) ([]Transition, error)
+	RecordCandidate(ctx context.Context, c Candidate) (Candidate, error)
+	GetCandidate(ctx context.Context, tenantID int64, id string) (Candidate, bool, error)
+	ListCandidates(ctx context.Context, q CandidateQuery) ([]Candidate, error)
+}
+
+// NoopStore is a disabled decision store implementation.
+type NoopStore struct{}
+
+func (NoopStore) Init(context.Context) error { return nil }
+func (NoopStore) UpsertDecision(_ context.Context, d Decision) (Decision, error) {
+	return d, nil
+}
+func (NoopStore) GetDecision(context.Context, int64, string) (Decision, bool, error) {
+	return Decision{}, false, nil
+}
+func (NoopStore) SearchDecisions(context.Context, SearchQuery) ([]SearchResult, error) {
+	return nil, nil
+}
+func (NoopStore) AddAssumption(_ context.Context, a AssumptionLink) (AssumptionLink, error) {
+	return a, nil
+}
+func (NoopStore) ListAssumptions(context.Context, AssumptionQuery) ([]AssumptionLink, error) {
+	return nil, nil
+}
+func (NoopStore) AddAlternative(_ context.Context, alt Alternative) (Alternative, error) {
+	return alt, nil
+}
+func (NoopStore) ListAlternatives(context.Context, int64, string) ([]Alternative, error) {
+	return nil, nil
+}
+func (NoopStore) AddEvidence(_ context.Context, e DecisionEvidence) (DecisionEvidence, error) {
+	return e, nil
+}
+func (NoopStore) ListEvidence(context.Context, EvidenceQuery) ([]DecisionEvidence, error) {
+	return nil, nil
+}
+func (NoopStore) RecordTransition(_ context.Context, t Transition) (Transition, error) {
+	return t, nil
+}
+func (NoopStore) ListTransitions(context.Context, TransitionQuery) ([]Transition, error) {
+	return nil, nil
+}
+func (NoopStore) RecordCandidate(_ context.Context, c Candidate) (Candidate, error) {
+	return c, nil
+}
+func (NoopStore) GetCandidate(context.Context, int64, string) (Candidate, bool, error) {
+	return Candidate{}, false, nil
+}
+func (NoopStore) ListCandidates(context.Context, CandidateQuery) ([]Candidate, error) {
+	return nil, nil
+}

--- a/internal/agent/memory/decision/types.go
+++ b/internal/agent/memory/decision/types.go
@@ -1,0 +1,240 @@
+package decision
+
+import "time"
+
+// DecisionStatus describes where a recorded decision sits in its lifecycle.
+type DecisionStatus string
+
+const (
+	// DecisionStatusProposed marks a drafted decision that is not yet in force.
+	DecisionStatusProposed DecisionStatus = "proposed"
+	// DecisionStatusActive marks a confirmed decision that should guide future work.
+	DecisionStatusActive DecisionStatus = "active"
+	// DecisionStatusStale marks a decision whose load-bearing assumptions changed.
+	DecisionStatusStale DecisionStatus = "stale"
+	// DecisionStatusSuperseded marks a decision replaced by another decision.
+	DecisionStatusSuperseded DecisionStatus = "superseded"
+	// DecisionStatusRevoked marks a decision explicitly reversed.
+	DecisionStatusRevoked DecisionStatus = "revoked"
+)
+
+// ReviewState mirrors belief.ReviewState values for operator workflows.
+type ReviewState string
+
+const (
+	// ReviewStateAutoActive marks records accepted by an automated policy.
+	ReviewStateAutoActive ReviewState = "auto_active"
+	// ReviewStateNeedsReview marks records requiring operator review.
+	ReviewStateNeedsReview ReviewState = "needs_review"
+	// ReviewStateOperatorApproved marks records approved by an operator.
+	ReviewStateOperatorApproved ReviewState = "operator_approved"
+	// ReviewStateOperatorRejected marks records rejected by an operator.
+	ReviewStateOperatorRejected ReviewState = "operator_rejected"
+)
+
+// CandidateValidationStatus describes whether a distiller candidate was accepted.
+type CandidateValidationStatus string
+
+const (
+	// CandidateValidationAccepted marks a candidate accepted into a decision.
+	CandidateValidationAccepted CandidateValidationStatus = "accepted"
+	// CandidateValidationQueued marks a candidate awaiting operator action.
+	CandidateValidationQueued CandidateValidationStatus = "queued"
+	// CandidateValidationRejected marks a candidate rejected during validation.
+	CandidateValidationRejected CandidateValidationStatus = "rejected"
+)
+
+// EvidencePolarity describes whether evidence supports or contradicts a decision.
+type EvidencePolarity string
+
+const (
+	// EvidencePolarityFor marks supporting evidence.
+	EvidencePolarityFor EvidencePolarity = "for"
+	// EvidencePolarityAgainst marks contradicting evidence.
+	EvidencePolarityAgainst EvidencePolarity = "against"
+)
+
+// AssumptionCriticality controls how belief changes affect a decision.
+type AssumptionCriticality string
+
+const (
+	// CriticalityLoadBearing means invalidating the belief stales the decision.
+	CriticalityLoadBearing AssumptionCriticality = "load_bearing"
+	// CriticalitySupporting means invalidating the belief flags the decision for review.
+	CriticalitySupporting AssumptionCriticality = "supporting"
+	// CriticalityContextual means the belief is informational only.
+	CriticalityContextual AssumptionCriticality = "contextual"
+)
+
+// TransitionTriggerKind identifies what caused a decision lifecycle audit row.
+type TransitionTriggerKind string
+
+const (
+	// TriggerBeliefChange marks a transition caused by a belief status or confidence change.
+	TriggerBeliefChange TransitionTriggerKind = "belief_change"
+	// TriggerOperator marks an operator-initiated transition.
+	TriggerOperator TransitionTriggerKind = "operator"
+	// TriggerSupersession marks a transition caused by another decision replacing this one.
+	TriggerSupersession TransitionTriggerKind = "supersession"
+	// TriggerDistiller marks a transition caused by candidate distillation.
+	TriggerDistiller TransitionTriggerKind = "distiller"
+)
+
+// Decision is the first-class "we chose X" record.
+type Decision struct {
+	ID            string         `json:"id"`
+	TenantID      int64          `json:"tenantId"`
+	ScopeID       string         `json:"scopeId"`
+	EpisodeID     string         `json:"episodeId,omitempty"`
+	Title         string         `json:"title"`
+	Statement     string         `json:"statement"`
+	StatementHash string         `json:"statementHash"`
+	Rationale     string         `json:"rationale"`
+	DecidedBy     string         `json:"decidedBy"`
+	DecidedAt     time.Time      `json:"decidedAt"`
+	Status        DecisionStatus `json:"status"`
+	ReviewState   ReviewState    `json:"reviewState"`
+	Confidence    float64        `json:"confidence"`
+	SupersededBy  string         `json:"supersededBy,omitempty"`
+	StaleReason   string         `json:"staleReason,omitempty"`
+	Embedding     []float32      `json:"-"`
+	Metadata      map[string]any `json:"metadata,omitempty"`
+	CreatedAt     time.Time      `json:"createdAt"`
+	UpdatedAt     time.Time      `json:"updatedAt"`
+}
+
+// AssumptionLink ties a decision to a belief it depends on.
+type AssumptionLink struct {
+	ID                     string                `json:"id"`
+	TenantID               int64                 `json:"tenantId"`
+	DecisionID             string                `json:"decisionId"`
+	BeliefID               string                `json:"beliefId"`
+	Criticality            AssumptionCriticality `json:"criticality"`
+	BeliefStatementAtLink  string                `json:"beliefStatementAtLink"`
+	BeliefConfidenceAtLink float64               `json:"beliefConfidenceAtLink"`
+	Note                   string                `json:"note,omitempty"`
+	Metadata               map[string]any        `json:"metadata,omitempty"`
+	CreatedAt              time.Time             `json:"createdAt"`
+}
+
+// Alternative records a path not taken and why.
+type Alternative struct {
+	ID              string         `json:"id"`
+	TenantID        int64          `json:"tenantId"`
+	DecisionID      string         `json:"decisionId"`
+	Statement       string         `json:"statement"`
+	RejectionReason string         `json:"rejectionReason"`
+	Metadata        map[string]any `json:"metadata,omitempty"`
+	CreatedAt       time.Time      `json:"createdAt"`
+}
+
+// DecisionEvidence links a decision to artifacts or other sources.
+type DecisionEvidence struct {
+	ID         string           `json:"id"`
+	TenantID   int64            `json:"tenantId"`
+	DecisionID string           `json:"decisionId"`
+	SourceKind string           `json:"sourceKind"`
+	SourceID   string           `json:"sourceId"`
+	Polarity   EvidencePolarity `json:"polarity"`
+	Weight     float64          `json:"weight"`
+	Note       string           `json:"note"`
+	Metadata   map[string]any   `json:"metadata,omitempty"`
+	CreatedAt  time.Time        `json:"createdAt"`
+}
+
+// Transition is an append-only audit record for decision lifecycle changes.
+type Transition struct {
+	ID          string                `json:"id"`
+	TenantID    int64                 `json:"tenantId"`
+	DecisionID  string                `json:"decisionId"`
+	FromStatus  DecisionStatus        `json:"fromStatus"`
+	ToStatus    DecisionStatus        `json:"toStatus"`
+	Reason      string                `json:"reason"`
+	TriggerKind TransitionTriggerKind `json:"triggerKind"`
+	TriggerID   string                `json:"triggerId"`
+	ActorUserID *int64                `json:"actorUserId,omitempty"`
+	CreatedAt   time.Time             `json:"createdAt"`
+}
+
+// Candidate is a distiller-proposed decision awaiting validation or acceptance.
+type Candidate struct {
+	ID                 string                    `json:"id"`
+	TenantID           int64                     `json:"tenantId"`
+	EpisodeID          string                    `json:"episodeId"`
+	ScopeID            string                    `json:"scopeId"`
+	Title              string                    `json:"title"`
+	Statement          string                    `json:"statement"`
+	StatementHash      string                    `json:"statementHash"`
+	Rationale          string                    `json:"rationale"`
+	Alternatives       []Alternative             `json:"alternatives,omitempty"`
+	AssumptionHints    []string                  `json:"assumptionHints,omitempty"`
+	EvidenceHints      []EvidenceHint            `json:"evidenceHints,omitempty"`
+	Confidence         float64                   `json:"confidence"`
+	ReviewState        ReviewState               `json:"reviewState"`
+	ValidationStatus   CandidateValidationStatus `json:"validationStatus"`
+	RejectionReason    string                    `json:"rejectionReason,omitempty"`
+	AcceptedDecisionID string                    `json:"acceptedDecisionId,omitempty"`
+	Model              string                    `json:"model,omitempty"`
+	RawPayload         string                    `json:"rawPayload,omitempty"`
+	Metadata           map[string]any            `json:"metadata,omitempty"`
+	CreatedAt          time.Time                 `json:"createdAt"`
+	UpdatedAt          time.Time                 `json:"updatedAt"`
+}
+
+// EvidenceHint is a distiller-proposed evidence link.
+type EvidenceHint struct {
+	SourceKind string           `json:"sourceKind"`
+	SourceID   string           `json:"sourceId"`
+	Polarity   EvidencePolarity `json:"polarity"`
+	Note       string           `json:"note,omitempty"`
+}
+
+// SearchQuery constrains decision retrieval by tenant, scope, and status.
+type SearchQuery struct {
+	TenantID int64            `json:"tenantId"`
+	ScopeIDs []string         `json:"scopeIds,omitempty"`
+	Query    string           `json:"query,omitempty"`
+	Statuses []DecisionStatus `json:"statuses,omitempty"`
+	Limit    int              `json:"limit,omitempty"`
+}
+
+// AssumptionQuery filters decision assumption links.
+type AssumptionQuery struct {
+	TenantID   int64  `json:"tenantId"`
+	DecisionID string `json:"decisionId,omitempty"`
+	BeliefID   string `json:"beliefId,omitempty"`
+	Limit      int    `json:"limit,omitempty"`
+}
+
+// EvidenceQuery filters decision evidence links.
+type EvidenceQuery struct {
+	TenantID   int64            `json:"tenantId"`
+	DecisionID string           `json:"decisionId,omitempty"`
+	SourceKind string           `json:"sourceKind,omitempty"`
+	SourceID   string           `json:"sourceId,omitempty"`
+	Polarity   EvidencePolarity `json:"polarity,omitempty"`
+	Limit      int              `json:"limit,omitempty"`
+}
+
+// TransitionQuery filters decision transition audit rows.
+type TransitionQuery struct {
+	TenantID   int64  `json:"tenantId"`
+	DecisionID string `json:"decisionId,omitempty"`
+	Limit      int    `json:"limit,omitempty"`
+}
+
+// CandidateQuery filters decision candidates.
+type CandidateQuery struct {
+	TenantID         int64                     `json:"tenantId"`
+	EpisodeID        string                    `json:"episodeId,omitempty"`
+	ReviewState      ReviewState               `json:"reviewState,omitempty"`
+	ValidationStatus CandidateValidationStatus `json:"validationStatus,omitempty"`
+	Limit            int                       `json:"limit,omitempty"`
+}
+
+// SearchResult is a scored decision retrieval result.
+type SearchResult struct {
+	Decision Decision `json:"decision"`
+	Score    float64  `json:"score"`
+	Reason   string   `json:"reason,omitempty"`
+}

--- a/internal/agent/memory/evolving_scoring.go
+++ b/internal/agent/memory/evolving_scoring.go
@@ -17,6 +17,7 @@ func (em *EvolvingMemory) relevanceBasedPrune(ctx context.Context) {
 	filtered := make([]*MemoryEntry, 0, len(em.entries))
 	protected := make([]*MemoryEntry, 0)
 	removedIDs := make([]string, 0)
+	removedEntries := make([]*MemoryEntry, 0)
 	for _, e := range em.entries {
 		if em.isProtectedByQualityFloor(e) {
 			protected = append(protected, e)
@@ -27,6 +28,7 @@ func (em *EvolvingMemory) relevanceBasedPrune(ctx context.Context) {
 			filtered = append(filtered, e)
 		} else {
 			removedIDs = append(removedIDs, e.ID)
+			removedEntries = append(removedEntries, cloneEntry(e))
 		}
 	}
 	em.entries = append(protected, filtered...)
@@ -48,8 +50,10 @@ func (em *EvolvingMemory) relevanceBasedPrune(ctx context.Context) {
 	}
 	for i := 0; i < toRemove; i++ {
 		removedIDs = append(removedIDs, filtered[i].ID)
+		removedEntries = append(removedEntries, cloneEntry(filtered[i]))
 	}
 	em.entries = append(protected, filtered[toRemove:]...)
+	em.archivePruned(ctx, removedEntries, "relevance")
 	em.markDeletedLocked(removedIDs)
 
 	// Re-sort by creation time to maintain temporal order
@@ -63,6 +67,19 @@ func (em *EvolvingMemory) relevanceBasedPrune(ctx context.Context) {
 		Msg("evolving_memory_relevance_pruned")
 	if em.metrics != nil && len(removedIDs) > 0 {
 		em.metrics.RecordPruned(ctx, "relevance", len(removedIDs))
+	}
+}
+
+func (em *EvolvingMemory) archivePruned(ctx context.Context, entries []*MemoryEntry, reason string) {
+	if em == nil || len(entries) == 0 || em.store == nil {
+		return
+	}
+	archive, ok := em.store.(EvolvingMemoryArchiveStore)
+	if !ok {
+		return
+	}
+	if err := archive.Archive(ctx, em.userID, em.sessionID, entries, reason); err != nil {
+		observability.LoggerWithTrace(ctx).Warn().Err(err).Str("reason", reason).Msg("evolving_memory_archive_failed")
 	}
 }
 

--- a/internal/agent/memory/evolving_types.go
+++ b/internal/agent/memory/evolving_types.go
@@ -207,6 +207,12 @@ type EvolvingMemoryDeltaStore interface {
 	TouchAccess(ctx context.Context, ids []string, at time.Time) error
 }
 
+// EvolvingMemoryArchiveStore is an optional extension for stores that preserve
+// entries before pruning removes them from the hot set.
+type EvolvingMemoryArchiveStore interface {
+	Archive(ctx context.Context, userID int64, sessionID string, entries []*MemoryEntry, reason string) error
+}
+
 // EvolvingMemorySearchStore is an optional extension for stores that can run
 // vector retrieval close to the data instead of requiring an in-process scan.
 type EvolvingMemorySearchStore interface {

--- a/internal/agent/memory/magma/graph_views.go
+++ b/internal/agent/memory/magma/graph_views.go
@@ -2,6 +2,7 @@ package magma
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"slices"
@@ -243,12 +244,55 @@ func (s *Store) DeleteEvent(ctx context.Context, id string) error {
 	return maintenance.DeleteMagmaEvent(ctx, id)
 }
 
+func (s *Store) ArchiveEvent(ctx context.Context, event EventNode, reason string) error {
+	if s == nil || s.graph == nil || strings.TrimSpace(event.ID) == "" {
+		return nil
+	}
+	archivedAt := time.Now().UTC()
+	props := map[string]any{
+		"archive_kind": "event",
+		"original_id":  event.ID,
+		"tenant":       event.Tenant,
+		"session":      event.Session,
+		"reason":       strings.TrimSpace(reason),
+		"payload":      mustJSON(event),
+		"archived_at":  archivedAt.Format(time.RFC3339Nano),
+	}
+	return s.graph.UpsertNode(ctx, magmaArchiveID("event", event.ID, archivedAt), []string{"MagmaArchive"}, props)
+}
+
+func (s *Store) ArchiveEdge(ctx context.Context, edge Edge, reason string) error {
+	if s == nil || s.graph == nil || strings.TrimSpace(edge.Source) == "" || strings.TrimSpace(edge.Target) == "" {
+		return nil
+	}
+	archivedAt := time.Now().UTC()
+	selector := selectorForEdge(edge)
+	originalID := strings.Join([]string{selector.Source, string(selector.GraphType), selector.Rel, selector.Target}, "\x00")
+	props := map[string]any{
+		"archive_kind": "edge",
+		"original_id":  originalID,
+		"source":       edge.Source,
+		"graph_type":   string(edge.GraphType),
+		"rel":          edge.Rel,
+		"target":       edge.Target,
+		"reason":       strings.TrimSpace(reason),
+		"payload":      mustJSON(edge),
+		"archived_at":  archivedAt.Format(time.RFC3339Nano),
+	}
+	return s.graph.UpsertNode(ctx, magmaArchiveID("edge", originalID, archivedAt), []string{"MagmaArchive"}, props)
+}
+
 func (s *Store) MaintenanceEnabled() bool {
 	if s == nil || s.graph == nil {
 		return false
 	}
 	_, ok := s.graph.(databases.MagmaGraphMaintenanceDB)
 	return ok
+}
+
+func magmaArchiveID(kind, original string, archivedAt time.Time) string {
+	sum := sha256.Sum256([]byte(kind + "\x00" + original + "\x00" + archivedAt.Format(time.RFC3339Nano)))
+	return fmt.Sprintf("magma_archive:%s:%x", kind, sum[:12])
 }
 
 func eventFromNode(node databases.Node) EventNode {

--- a/internal/agent/memory/magma/lifecycle.go
+++ b/internal/agent/memory/magma/lifecycle.go
@@ -16,6 +16,7 @@ func (s *Service) Prune(ctx context.Context, policy LifecyclePolicy) (stats Life
 		attribute.Int("magma.lifecycle.max_edges_per_source_rel", policy.MaxEdgesPerSourceRel),
 		attribute.Float64("magma.lifecycle.min_semantic_weight", policy.MinSemanticWeight),
 		attribute.Float64("magma.lifecycle.low_confidence_threshold", policy.LowConfidenceThreshold),
+		attribute.Bool("magma.lifecycle.archive_before_delete", policy.ArchiveBeforeDelete),
 	)
 	defer endSpan(span, &err)
 
@@ -82,12 +83,43 @@ func (s *Service) ApproveEdge(ctx context.Context, selector EdgeSelector, review
 		}
 		edge.Props["review_state"] = "approved"
 		edge.Props["reviewed_at"] = time.Now().UTC().Format(time.RFC3339Nano)
+		edge.Props["approved_at"] = edge.Props["reviewed_at"]
 		if strings.TrimSpace(reviewer) != "" {
 			edge.Props["reviewed_by"] = strings.TrimSpace(reviewer)
+			edge.Props["approved_by"] = strings.TrimSpace(reviewer)
 		}
 		return edge
 	})
 	return err
+}
+
+// GroundEdge appends evidence to a selected edge and clears grounding-only review flags.
+func (s *Service) GroundEdge(ctx context.Context, selector EdgeSelector, evidence []EvidenceRef) error {
+	if len(evidence) == 0 {
+		return nil
+	}
+	return s.updateSelectedEdge(ctx, selector, func(edge Edge) Edge {
+		if edge.Props == nil {
+			edge.Props = map[string]any{}
+		}
+		existing := evidenceList(edge.Props["evidence"])
+		for _, ref := range evidence {
+			if strings.TrimSpace(ref.SourceKind) == "" || strings.TrimSpace(ref.SourceID) == "" {
+				continue
+			}
+			existing = append(existing, map[string]string{
+				"sourceKind": strings.TrimSpace(ref.SourceKind),
+				"sourceId":   strings.TrimSpace(ref.SourceID),
+			})
+		}
+		edge.Props["evidence"] = existing
+		if stringProp(edge.Props, "review_state") == "needs_review" && stringProp(edge.Props, "review_reason") == "ungrounded_causal" {
+			delete(edge.Props, "review_state")
+			delete(edge.Props, "review_reason")
+			delete(edge.Props, "flagged_at")
+		}
+		return edge
+	})
 }
 
 func (s *Service) RetractEdge(ctx context.Context, selector EdgeSelector, reason string) error {
@@ -99,6 +131,17 @@ func (s *Service) RetractEdge(ctx context.Context, selector EdgeSelector, reason
 	defer endSpan(span, &err)
 	if s == nil || s.store == nil {
 		return errors.New("magma service is not configured")
+	}
+	if s.cfg.Lifecycle.ArchiveBeforeDelete {
+		edge, ok, err := s.selectedEdge(ctx, selector)
+		if err != nil {
+			return err
+		}
+		if ok {
+			if err := s.store.ArchiveEdge(ctx, edge, firstNonEmpty(strings.TrimSpace(reason), "manual_retraction")); err != nil {
+				return err
+			}
+		}
 	}
 	if err := s.store.DeleteEdge(ctx, selector); err != nil {
 		return err
@@ -124,8 +167,14 @@ func (s *Service) DeleteEvent(ctx context.Context, id string) (bool, error) {
 		err = errors.New("magma event id is required")
 		return false, err
 	}
-	if _, ok := s.store.GetEvent(ctx, id); !ok {
+	event, ok := s.store.GetEvent(ctx, id)
+	if !ok {
 		return false, nil
+	}
+	if s.cfg.Lifecycle.ArchiveBeforeDelete {
+		if err = s.archiveEventCascade(ctx, event, "manual_deletion", nil); err != nil {
+			return true, err
+		}
 	}
 	if err = s.store.DeleteEvent(ctx, id); err != nil {
 		return true, err
@@ -152,6 +201,11 @@ func (s *Service) pruneExpiredEvents(ctx context.Context, policy LifecyclePolicy
 		if event.CreatedAt.IsZero() || !event.CreatedAt.Before(cutoff) {
 			continue
 		}
+		if policy.ArchiveBeforeDelete {
+			if err := s.archiveEventCascade(ctx, event, "expired", stats); err != nil {
+				return err
+			}
+		}
 		if err := s.store.DeleteEvent(ctx, event.ID); err != nil {
 			return err
 		}
@@ -171,6 +225,11 @@ func (s *Service) pruneEdges(ctx context.Context, policy LifecyclePolicy, stats 
 	grouped := make(map[string][]Edge)
 	for _, edge := range edges {
 		if shouldDeleteByWeight(edge, policy) {
+			if policy.ArchiveBeforeDelete {
+				if err := s.archiveEdgeBeforeDelete(ctx, edge, "low_weight", stats); err != nil {
+					return err
+				}
+			}
 			if err := s.store.DeleteEdge(ctx, selectorForEdge(edge)); err != nil {
 				return err
 			}
@@ -203,6 +262,11 @@ func (s *Service) pruneEdges(ctx context.Context, policy LifecyclePolicy, stats 
 		}
 		sort.SliceStable(group, func(i, j int) bool { return edgeRank(group[i]) > edgeRank(group[j]) })
 		for _, edge := range group[policy.MaxEdgesPerSourceRel:] {
+			if policy.ArchiveBeforeDelete {
+				if err := s.archiveEdgeBeforeDelete(ctx, edge, "fanout", stats); err != nil {
+					return err
+				}
+			}
 			if err := s.store.DeleteEdge(ctx, selectorForEdge(edge)); err != nil {
 				return err
 			}
@@ -210,6 +274,63 @@ func (s *Service) pruneEdges(ctx context.Context, policy LifecyclePolicy, stats 
 		}
 	}
 	return nil
+}
+
+func (s *Service) archiveEventCascade(ctx context.Context, event EventNode, reason string, stats *LifecycleStats) error {
+	if s == nil || s.store == nil {
+		return errors.New("magma service is not configured")
+	}
+	edges, err := s.store.ListEdges(ctx)
+	if err != nil {
+		return err
+	}
+	for _, edge := range edges {
+		if edge.Source != event.ID && edge.Target != event.ID {
+			continue
+		}
+		if err := s.store.ArchiveEdge(ctx, edge, reason+"_incident_edge"); err != nil {
+			return err
+		}
+		if stats != nil {
+			stats.EdgesArchived++
+		}
+	}
+	if err := s.store.ArchiveEvent(ctx, event, reason); err != nil {
+		return err
+	}
+	if stats != nil {
+		stats.EventsArchived++
+	}
+	return nil
+}
+
+func (s *Service) archiveEdgeBeforeDelete(ctx context.Context, edge Edge, reason string, stats *LifecycleStats) error {
+	if s == nil || s.store == nil {
+		return errors.New("magma service is not configured")
+	}
+	if err := s.store.ArchiveEdge(ctx, edge, reason); err != nil {
+		return err
+	}
+	if stats != nil {
+		stats.EdgesArchived++
+	}
+	return nil
+}
+
+func (s *Service) selectedEdge(ctx context.Context, selector EdgeSelector) (Edge, bool, error) {
+	if s == nil || s.store == nil {
+		return Edge{}, false, errors.New("magma service is not configured")
+	}
+	edges, err := s.store.ListEdges(ctx)
+	if err != nil {
+		return Edge{}, false, err
+	}
+	for _, edge := range edges {
+		if selectorForEdge(edge) == selector {
+			return edge, true, nil
+		}
+	}
+	return Edge{}, false, nil
 }
 
 func (s *Service) updateSelectedEdge(ctx context.Context, selector EdgeSelector, update func(Edge) Edge) error {
@@ -257,6 +378,41 @@ func edgeConfidence(edge Edge) float64 {
 
 func edgeReviewState(edge Edge) string {
 	return stringProp(edge.Props, "review_state")
+}
+
+func evidenceList(raw any) []map[string]string {
+	out := []map[string]string{}
+	switch values := raw.(type) {
+	case []map[string]string:
+		return append(out, values...)
+	case []map[string]any:
+		for _, value := range values {
+			out = append(out, map[string]string{
+				"sourceKind": stringFromAny(value["sourceKind"]),
+				"sourceId":   stringFromAny(value["sourceId"]),
+			})
+		}
+	case []any:
+		for _, item := range values {
+			if m, ok := item.(map[string]any); ok {
+				out = append(out, map[string]string{
+					"sourceKind": stringFromAny(m["sourceKind"]),
+					"sourceId":   stringFromAny(m["sourceId"]),
+				})
+			}
+		}
+	}
+	return out
+}
+
+func stringFromAny(value any) string {
+	if value == nil {
+		return ""
+	}
+	if s, ok := value.(string); ok {
+		return s
+	}
+	return ""
 }
 
 func stringProp(props map[string]any, key string) string {

--- a/internal/agent/memory/magma/llm_consolidation.go
+++ b/internal/agent/memory/magma/llm_consolidation.go
@@ -84,11 +84,19 @@ func (s *Service) extractWithLLM(ctx context.Context, event EventNode) (llmExtra
 			Target:    event.ID,
 			Props: map[string]any{
 				"confidence":  confidence,
+				"origin":      "llm_consolidation",
+				"model":       s.cfg.Model,
 				"extractor":   "llm",
 				"cause_text":  cause,
 				"effect_text": effect,
 			},
 		})
+		if s.cfg.RequireCausalGrounding {
+			edge := &extracted.CausalEdges[len(extracted.CausalEdges)-1]
+			edge.Props["review_state"] = "needs_review"
+			edge.Props["review_reason"] = "ungrounded_causal"
+			edge.Props["flagged_at"] = time.Now().UTC().Format(time.RFC3339Nano)
+		}
 	}
 	return extracted, extracted.TemporalAttrs != (TemporalAttrs{}) || len(extracted.Entities) > 0 || len(extracted.CausalEdges) > 0
 }

--- a/internal/agent/memory/magma/service_test.go
+++ b/internal/agent/memory/magma/service_test.go
@@ -1096,6 +1096,34 @@ func TestService_PruneExpiresEventsAndDeletesVector(t *testing.T) {
 	}
 }
 
+func TestService_PruneArchivesExpiredEventsBeforeDelete(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	svc := NewService(databases.NewMemoryGraph(), nil, embedder.NewDeterministic(32, true, 0))
+	old := EventNode{ID: "event:t1:old", Tenant: "t1", Text: "old", CreatedAt: time.Now().Add(-48 * time.Hour)}
+	newer := EventNode{ID: "event:t1:new", Tenant: "t1", Text: "new", CreatedAt: time.Now()}
+	if err := svc.store.StoreEvent(ctx, old); err != nil {
+		t.Fatalf("StoreEvent(old) error = %v", err)
+	}
+	if err := svc.store.StoreEvent(ctx, newer); err != nil {
+		t.Fatalf("StoreEvent(new) error = %v", err)
+	}
+	if err := svc.store.UpsertEdge(ctx, Edge{Source: old.ID, GraphType: GraphSemantic, Rel: "SIMILAR_TO", Target: newer.ID, Weight: 0.9}); err != nil {
+		t.Fatalf("UpsertEdge() error = %v", err)
+	}
+
+	stats, err := svc.Prune(ctx, LifecyclePolicy{EventTTL: 24 * time.Hour, ArchiveBeforeDelete: true})
+	if err != nil {
+		t.Fatalf("Prune() error = %v", err)
+	}
+	if stats.EventsDeleted != 1 || stats.EventsArchived != 1 || stats.EdgesArchived != 1 {
+		t.Fatalf("expected event and incident edge archive before delete, got %#v", stats)
+	}
+	if _, ok := svc.Event(ctx, old.ID); ok {
+		t.Fatalf("expected old event to be deleted")
+	}
+}
+
 func TestService_PruneEdgesByWeightAndFanout(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
@@ -1130,6 +1158,29 @@ func TestService_PruneEdgesByWeightAndFanout(t *testing.T) {
 	}
 	if len(neighbors) != 1 || neighbors[0] != "event:t1:keep" {
 		t.Fatalf("expected only strongest edge to remain, got %#v", neighbors)
+	}
+}
+
+func TestService_PruneArchivesEdgesBeforeDelete(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	svc := NewServiceWithConfig(databases.NewMemoryGraph(), nil, embedder.NewDeterministic(32, true, 0), ServiceConfig{
+		Graphs: GraphConfig{Semantic: true},
+	})
+	for _, id := range []string{"source", "drop"} {
+		if err := svc.store.StoreEvent(ctx, EventNode{ID: "event:t1:" + id, Tenant: "t1", Text: id, CreatedAt: time.Now()}); err != nil {
+			t.Fatalf("StoreEvent(%s) error = %v", id, err)
+		}
+	}
+	if err := svc.store.UpsertEdge(ctx, Edge{Source: "event:t1:source", GraphType: GraphSemantic, Rel: "SIMILAR_TO", Target: "event:t1:drop", Weight: 0.25}); err != nil {
+		t.Fatalf("UpsertEdge() error = %v", err)
+	}
+	stats, err := svc.Prune(ctx, LifecyclePolicy{MinSemanticWeight: 0.5, ArchiveBeforeDelete: true})
+	if err != nil {
+		t.Fatalf("Prune() error = %v", err)
+	}
+	if stats.EdgesDeleted != 1 || stats.EdgesArchived != 1 {
+		t.Fatalf("expected edge archive before delete, got %#v", stats)
 	}
 }
 

--- a/internal/agent/memory/magma/types.go
+++ b/internal/agent/memory/magma/types.go
@@ -103,11 +103,14 @@ type LifecyclePolicy struct {
 	MinSemanticWeight      float64
 	LowConfidenceThreshold float64
 	RequireReviewApproval  bool
+	ArchiveBeforeDelete    bool
 }
 
 type LifecycleStats struct {
 	EventsDeleted       int
 	EdgesDeleted        int
+	EventsArchived      int
+	EdgesArchived       int
 	EdgesFlaggedReview  int
 	EdgesSkippedReview  int
 	MaintenanceDisabled bool
@@ -214,17 +217,24 @@ type ServiceStats struct {
 }
 
 type ServiceConfig struct {
-	QueueSize           int
-	BatchSize           int
-	SemanticTopK        int
-	SimilarityThreshold float64
-	CausalThreshold     float64
-	LLM                 llm.Provider
-	Model               string
-	Prompts             PromptConfig
-	Graphs              GraphConfig
-	Lifecycle           LifecyclePolicy
-	Observer            Observer
+	QueueSize              int
+	BatchSize              int
+	SemanticTopK           int
+	SimilarityThreshold    float64
+	CausalThreshold        float64
+	LLM                    llm.Provider
+	Model                  string
+	Prompts                PromptConfig
+	Graphs                 GraphConfig
+	Lifecycle              LifecyclePolicy
+	RequireCausalGrounding bool
+	Observer               Observer
+}
+
+// EvidenceRef identifies evidence that grounds a graph edge.
+type EvidenceRef struct {
+	SourceKind string `json:"sourceKind"`
+	SourceID   string `json:"sourceId"`
 }
 
 type PromptConfig struct {

--- a/internal/agentd/app_init_tools.go
+++ b/internal/agentd/app_init_tools.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/rs/zerolog/log"
 
+	decisionmem "manifold/internal/agent/memory/decision"
 	appcodeqa "manifold/internal/codeqa"
 	codeqaservice "manifold/internal/codeqa/service"
 	codeqastore "manifold/internal/codeqa/store"
@@ -22,6 +23,7 @@ import (
 	"manifold/internal/tools/cli"
 	codeevolvetool "manifold/internal/tools/codeevolve"
 	codeqatool "manifold/internal/tools/codeqa"
+	decisiontools "manifold/internal/tools/decision"
 	"manifold/internal/tools/filetool"
 	"manifold/internal/tools/imagetool"
 	"manifold/internal/tools/llmparallel"
@@ -80,6 +82,7 @@ func initAppTooling(ctx context.Context, cfg *config.Config, httpClient *http.Cl
 	toolRegistry.Register(codeqatool.NewRun(cfg, codeQAService))
 	toolRegistry.Register(codeqatool.NewOptimize(cfg, codeQAService))
 	transitSvc := initTransitService(cfg, mgr, runtimeRAGService, toolRegistry)
+	registerDecisionTools(cfg, mgr, toolRegistry)
 	registerImageTool(cfg, httpClient, llm, toolRegistry)
 
 	return appTooling{
@@ -233,6 +236,17 @@ func initTransitService(cfg *config.Config, mgr databases.Manager, runtimeRAGSer
 	toolRegistry.Register(transittools.NewListKeysTool(transitSvc))
 	toolRegistry.Register(transittools.NewListRecentTool(transitSvc))
 	return transitSvc
+}
+
+func registerDecisionTools(cfg *config.Config, mgr databases.Manager, toolRegistry tools.Registry) {
+	if cfg == nil || !cfg.Archaeology.Enabled || mgr.Decision == nil {
+		return
+	}
+	service := &decisionmem.Service{Store: mgr.Decision, Belief: mgr.Belief}
+	toolRegistry.Register(decisiontools.NewSearchTool(mgr.Decision))
+	toolRegistry.Register(decisiontools.NewReconstructTool(service, mgr.Belief, mgr.Artifact))
+	toolRegistry.Register(decisiontools.NewRecordTool(service))
+	toolRegistry.Register(decisiontools.NewReviewTool(service))
 }
 
 func registerImageTool(cfg *config.Config, httpClient *http.Client, llm llmpkg.Provider, toolRegistry tools.Registry) {

--- a/internal/agentd/chat_execution.go
+++ b/internal/agentd/chat_execution.go
@@ -153,8 +153,11 @@ func buildChatJSONPayload(result string, images []savedImage, ctx context.Contex
 	return payload
 }
 
-func buildChatStreamFinalPayload(result string, ctx context.Context, includeMatrixMessages bool) map[string]any {
+func buildChatStreamFinalPayload(result string, ctx context.Context, includeMatrixMessages bool, durationMs ...int64) map[string]any {
 	payload := map[string]any{"type": "final", "data": result}
+	if len(durationMs) > 0 && durationMs[0] >= 0 {
+		payload["durationMs"] = durationMs[0]
+	}
 	if includeMatrixMessages {
 		if outbox, ok := sandbox.MatrixOutboxFromContext(ctx); ok {
 			if messages := outbox.Messages(); len(messages) > 0 {
@@ -518,7 +521,9 @@ func (a *app) executeStreamChat(w http.ResponseWriter, r *http.Request, exec cha
 	collector := newChatTurnCollector(sandbox.ResolveBaseDir(ctx, a.cfg.Workdir), req.ProjectID, stream)
 	collector.attach(eng)
 
+	assistantStartedAt := time.Now()
 	result, err := eng.RunStream(ctx, req.Prompt, history)
+	durationMs := time.Since(assistantStartedAt).Milliseconds()
 	if err != nil {
 		a.handleStreamChatError(ctx, r, stream, checkedOutWorkspace, streamChatErrorRequest{
 			RunID:   runID,
@@ -530,14 +535,15 @@ func (a *app) executeStreamChat(w http.ResponseWriter, r *http.Request, exec cha
 		return
 	}
 	a.finishStreamChatSuccess(stream, collector, eng, streamChatSuccessRequest{
-		Context:   ctx,
-		StoreCtx:  r.Context(),
-		RunID:     runID,
-		Request:   req,
-		UserID:    userID,
-		Options:   opts,
-		Result:    result,
-		Workspace: checkedOutWorkspace,
+		Context:    ctx,
+		StoreCtx:   r.Context(),
+		RunID:      runID,
+		Request:    req,
+		UserID:     userID,
+		Options:    opts,
+		Result:     result,
+		DurationMs: durationMs,
+		Workspace:  checkedOutWorkspace,
 	})
 }
 
@@ -584,7 +590,9 @@ func (a *app) executeInternalJSONChat(storeCtx context.Context, exec chatExecuti
 	collector := newChatTurnCollector(sandbox.ResolveBaseDir(ctx, a.cfg.Workdir), req.ProjectID, nil)
 	collector.attach(eng)
 
+	assistantStartedAt := time.Now()
 	result, err := eng.Run(ctx, req.Prompt, history)
+	durationMs := time.Since(assistantStartedAt).Milliseconds()
 	if err != nil {
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 			log.Warn().Err(err).Msg("agent run cancelled")
@@ -612,6 +620,7 @@ func (a *app) executeInternalJSONChat(storeCtx context.Context, exec chatExecuti
 		TurnMessages:       collector.turnMessages,
 		FinalContent:       result,
 		AssistantMessageID: req.AssistantMessageID,
+		DurationMs:         &durationMs,
 		Model:              chatStoreModel(eng, opts.StoreModel),
 	}); err != nil {
 		log.Error().Err(err).Str("session", req.SessionID).Msg("store_chat_turn")

--- a/internal/agentd/chat_execution_test.go
+++ b/internal/agentd/chat_execution_test.go
@@ -61,6 +61,16 @@ func TestBuildChatStreamFinalPayloadOmitsMatrixMessagesWhenDisabled(t *testing.T
 	}
 }
 
+func TestBuildChatStreamFinalPayloadIncludesDuration(t *testing.T) {
+	t.Parallel()
+
+	payload := buildChatStreamFinalPayload("done", context.Background(), false, 12437)
+
+	if payload["durationMs"] != int64(12437) {
+		t.Fatalf("expected durationMs in payload, got %#v", payload)
+	}
+}
+
 func TestChatTurnCollectorResultTextAppendsImageSummary(t *testing.T) {
 	t.Parallel()
 

--- a/internal/agentd/chat_stream_execution_helpers.go
+++ b/internal/agentd/chat_stream_execution_helpers.go
@@ -27,14 +27,15 @@ type streamChatErrorRequest struct {
 }
 
 type streamChatSuccessRequest struct {
-	Context   context.Context
-	StoreCtx  context.Context
-	RunID     string
-	Request   chatRunRequest
-	UserID    *int64
-	Options   chatStreamOptions
-	Result    string
-	Workspace *workspaces.Workspace
+	Context    context.Context
+	StoreCtx   context.Context
+	RunID      string
+	Request    chatRunRequest
+	UserID     *int64
+	Options    chatStreamOptions
+	Result     string
+	DurationMs int64
+	Workspace  *workspaces.Workspace
 }
 
 type streamExecutionContextRequest struct {
@@ -194,7 +195,7 @@ func writeStreamChatError(stream *chatSSEWriter, err error, structured bool) {
 
 func (a *app) finishStreamChatSuccess(stream *chatSSEWriter, collector *chatTurnCollector, eng *agent.Engine, req streamChatSuccessRequest) {
 	result := collector.resultText(req.Result)
-	stream.write(buildChatStreamFinalPayload(result, req.Context, req.Options.IncludeMatrixMessages))
+	stream.write(buildChatStreamFinalPayload(result, req.Context, req.Options.IncludeMatrixMessages, req.DurationMs))
 	a.runs.updateStatus(req.RunID, "completed", 0)
 	a.publishChatRunEvent(fleet.EventRunFinished, req.RunID, req.Request, req.UserID, result)
 	a.storeStreamChatTurn(req.StoreCtx, collector, eng, req, result)
@@ -202,6 +203,7 @@ func (a *app) finishStreamChatSuccess(stream *chatSSEWriter, collector *chatTurn
 }
 
 func (a *app) storeStreamChatTurn(ctx context.Context, collector *chatTurnCollector, eng *agent.Engine, req streamChatSuccessRequest, result string) {
+	durationMs := req.DurationMs
 	if err := storeChatTurnWithHistory(ctx, a.chatStore, chatTurnHistoryRecord{
 		UserID:             req.UserID,
 		SessionID:          req.Request.SessionID,
@@ -210,6 +212,7 @@ func (a *app) storeStreamChatTurn(ctx context.Context, collector *chatTurnCollec
 		TurnMessages:       collector.turnMessages,
 		FinalContent:       result,
 		AssistantMessageID: req.Request.AssistantMessageID,
+		DurationMs:         &durationMs,
 		Model:              chatStoreModel(eng, req.Options.StoreModel),
 	}); err != nil {
 		log.Error().Err(err).Str("session", req.Request.SessionID).Msg("store_chat_turn_stream")

--- a/internal/agentd/durable_chat.go
+++ b/internal/agentd/durable_chat.go
@@ -654,11 +654,13 @@ func (a *app) runDurableChatTask(ctx context.Context, params map[string]any) (ma
 	stopHeartbeat := startDurableChatHeartbeat(exec.runCtx)
 	defer stopHeartbeat()
 
+	assistantStartedAt := time.Now()
 	result, err := exec.run()
+	durationMs := time.Since(assistantStartedAt).Milliseconds()
 	if err != nil {
 		return a.handleDurableChatRunError(exec, err)
 	}
-	return a.completeDurableChatRun(context.WithoutCancel(ctx), exec, result), nil
+	return a.completeDurableChatRun(context.WithoutCancel(ctx), exec, result, durationMs), nil
 }
 
 func (a *app) newDurableChatExecution(ctx context.Context, params map[string]any) (durableChatExecution, error) {
@@ -745,27 +747,28 @@ func (a *app) handleDurableChatRunError(exec durableChatExecution, err error) (m
 	return nil, err
 }
 
-func (a *app) completeDurableChatRun(storeCtx context.Context, exec durableChatExecution, result string) map[string]any {
+func (a *app) completeDurableChatRun(storeCtx context.Context, exec durableChatExecution, result string, durationMs int64) map[string]any {
 	result = exec.collector.resultText(result)
 	req := exec.prepared.exec.RunRequest
-	exec.writer.write(buildChatStreamFinalPayload(result, exec.runCtx, exec.prepared.streamOpts.IncludeMatrixMessages))
+	exec.writer.write(buildChatStreamFinalPayload(result, exec.runCtx, exec.prepared.streamOpts.IncludeMatrixMessages, durationMs))
 	a.runs.updateStatus(exec.task.ID, "completed", 0)
 	a.publishChatRunEvent(fleet.EventRunFinished, exec.task.ID, req, exec.prepared.exec.UserID, result)
 	a.storeStreamChatTurn(storeCtx, exec.collector, exec.prepared.exec.Engine, streamChatSuccessRequest{
-		Context:   exec.runCtx,
-		StoreCtx:  storeCtx,
-		RunID:     exec.task.ID,
-		Request:   req,
-		UserID:    exec.prepared.exec.UserID,
-		Options:   exec.prepared.streamOpts,
-		Result:    result,
-		Workspace: exec.prepared.exec.CheckedOutWorkspace,
+		Context:    exec.runCtx,
+		StoreCtx:   storeCtx,
+		RunID:      exec.task.ID,
+		Request:    req,
+		UserID:     exec.prepared.exec.UserID,
+		Options:    exec.prepared.streamOpts,
+		Result:     result,
+		DurationMs: durationMs,
+		Workspace:  exec.prepared.exec.CheckedOutWorkspace,
 	}, result)
 	a.commitWorkspace(exec.runCtx, exec.prepared.exec.CheckedOutWorkspace)
-	return durableChatResultPayload(exec.task.ID, req, result)
+	return durableChatResultPayload(exec.task.ID, req, result, durationMs)
 }
 
-func durableChatResultPayload(runID string, req chatRunRequest, result string) map[string]any {
+func durableChatResultPayload(runID string, req chatRunRequest, result string, durationMs int64) map[string]any {
 	return map[string]any{
 		"ok":                   true,
 		"run_id":               runID,
@@ -773,6 +776,7 @@ func durableChatResultPayload(runID string, req chatRunRequest, result string) m
 		"user_message_id":      req.UserMessageID,
 		"assistant_message_id": req.AssistantMessageID,
 		"result":               result,
+		"durationMs":           durationMs,
 	}
 }
 

--- a/internal/agentd/engine_runtime.go
+++ b/internal/agentd/engine_runtime.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"manifold/internal/agent"
 	"manifold/internal/agent/memory"
+	"manifold/internal/agent/memory/artifact"
+	artifactconnectors "manifold/internal/agent/memory/artifact/connectors"
 	"manifold/internal/agent/memory/belief"
+	"manifold/internal/agent/memory/decision"
 	"manifold/internal/agent/memory/magma"
 	"manifold/internal/config"
 	"manifold/internal/embedding"
@@ -265,6 +268,7 @@ func (a *app) configureBeliefRunState(eng *agent.Engine, userID int64, sessionID
 		} else {
 			eng.BeliefMagmaSink = nil
 		}
+		a.configureArchaeologyRunState(eng)
 	} else {
 		eng.BeliefStore = nil
 		eng.BeliefDistiller = nil
@@ -279,8 +283,79 @@ func (a *app) configureBeliefRunState(eng *agent.Engine, userID int64, sessionID
 		eng.BeliefEnforcementPolicy = belief.EnforcementPolicy{}
 		eng.BeliefPolicySink = nil
 		eng.BeliefMagmaSink = nil
+		eng.DecisionStore = nil
+		eng.DecisionDistiller = nil
+		eng.ArtifactCapture = nil
 		eng.PolicyEnforcer = nil
 	}
+}
+
+func (a *app) configureArchaeologyRunState(eng *agent.Engine) {
+	if a == nil || a.cfg == nil || a.mgr.Decision == nil || !a.cfg.Archaeology.Enabled {
+		eng.DecisionStore = nil
+		eng.DecisionDistiller = nil
+		eng.ArtifactCapture = nil
+		return
+	}
+	eng.DecisionStore = a.mgr.Decision
+	if a.cfg.Archaeology.DecisionDistiller {
+		eng.DecisionDistiller = a.newDecisionDistiller()
+	}
+	if a.mgr.Artifact != nil {
+		connectors := []artifact.Connector{artifactconnectors.GitConnector{}}
+		if a.mgr.Chat != nil {
+			connectors = append(connectors, artifactconnectors.ChatConnector{Store: a.mgr.Chat})
+		}
+		if a.mgr.Transit != nil {
+			connectors = append(connectors, artifactconnectors.TransitConnector{Store: a.mgr.Transit})
+		}
+		eng.ArtifactCapture = &artifact.CaptureManager{
+			Store:      a.mgr.Artifact,
+			Connectors: connectors,
+			Timeout:    10 * time.Second,
+			OnError: func(kind artifact.ArtifactKind, err error) {
+				log.Debug().Err(err).Str("kind", string(kind)).Msg("artifact_capture_skipped")
+			},
+		}
+	}
+	service := &decision.Service{Store: a.mgr.Decision, Belief: eng.BeliefStore}
+	reactor := &decision.Reactor{
+		Decisions: service,
+		Beliefs:   eng.BeliefStore,
+		Config: decision.ReactorConfig{
+			ConfidenceFloor:     a.cfg.Archaeology.Reactor.ConfidenceFloor,
+			ConfidenceDropDelta: a.cfg.Archaeology.Reactor.ConfidenceDropDelta,
+		},
+	}
+	if notifying, ok := eng.BeliefStore.(*belief.NotifyingStore); ok {
+		notifying.RegisterListener(reactor)
+		return
+	}
+	if eng.BeliefStore != nil {
+		notifying := belief.NewNotifyingStore(eng.BeliefStore, 256)
+		notifying.RegisterListener(reactor)
+		eng.BeliefStore = notifying
+	}
+}
+
+func (a *app) newDecisionDistiller() decision.Distiller {
+	var embed decision.EmbedFunc
+	cfg := a.cfg.Embedding
+	if strings.TrimSpace(cfg.BaseURL) != "" && strings.TrimSpace(cfg.Model) != "" {
+		embed = func(ctx context.Context, texts []string) ([][]float32, error) {
+			return embedding.EmbedText(ctx, cfg, texts)
+		}
+	}
+	if a.beliefLLM != nil {
+		return decision.LLMDistiller{Config: decision.LLMDistillerConfig{
+			LLM:                    a.beliefLLM,
+			Model:                  a.beliefModel,
+			MaxCandidates:          a.cfg.BeliefMemory.Distillation.MaxCandidatesPerEpisode,
+			MinCandidateConfidence: a.cfg.BeliefMemory.Distillation.MinCandidateConfidence,
+			Embed:                  embed,
+		}}
+	}
+	return decision.SimpleDistiller{Embed: embed}
 }
 
 func (a *app) newBeliefDistiller() belief.Distiller {

--- a/internal/agentd/utils.go
+++ b/internal/agentd/utils.go
@@ -134,6 +134,7 @@ type chatTurnRecord struct {
 	SessionID        string
 	UserContent      string
 	AssistantContent string
+	DurationMs       *int64
 	Model            string
 }
 
@@ -150,10 +151,11 @@ func storeChatTurn(ctx context.Context, store persist.ChatStore, record chatTurn
 	}
 	if strings.TrimSpace(record.AssistantContent) != "" {
 		messages = append(messages, persist.ChatMessage{
-			SessionID: record.SessionID,
-			Role:      "assistant",
-			Content:   record.AssistantContent,
-			CreatedAt: now.Add(2 * time.Millisecond),
+			SessionID:  record.SessionID,
+			Role:       "assistant",
+			Content:    record.AssistantContent,
+			CreatedAt:  now.Add(2 * time.Millisecond),
+			DurationMs: record.DurationMs,
 		})
 	}
 	if len(messages) == 0 {
@@ -176,6 +178,7 @@ type chatTurnHistoryRecord struct {
 	TurnMessages       []llm.Message
 	FinalContent       string
 	AssistantMessageID string
+	DurationMs         *int64
 	Model              string
 }
 
@@ -240,11 +243,12 @@ func storeChatTurnWithHistory(ctx context.Context, store persist.ChatStore, reco
 			messageID = stableTurnMessageID(record, msg.Role, i)
 		}
 		messages = append(messages, persist.ChatMessage{
-			ID:        messageID,
-			SessionID: record.SessionID,
-			Role:      msg.Role,
-			Content:   content,
-			CreatedAt: now.Add(time.Duration(i+1) * 10 * time.Millisecond),
+			ID:         messageID,
+			SessionID:  record.SessionID,
+			Role:       msg.Role,
+			Content:    content,
+			CreatedAt:  now.Add(time.Duration(i+1) * 10 * time.Millisecond),
+			DurationMs: durationForTurnMessage(record, msg.Role, i, lastAssistantIndex),
 		})
 	}
 
@@ -260,6 +264,13 @@ func storeChatTurnWithHistory(ctx context.Context, store persist.ChatStore, reco
 		preview = previewSnippet(record.UserContent)
 	}
 	return store.AppendMessagesOnce(ctx, record.UserID, record.SessionID, messages, preview, record.Model)
+}
+
+func durationForTurnMessage(record chatTurnHistoryRecord, role string, index, lastAssistantIndex int) *int64 {
+	if role != "assistant" || index != lastAssistantIndex {
+		return nil
+	}
+	return record.DurationMs
 }
 
 func stableTurnMessageID(record chatTurnHistoryRecord, role string, index int) string {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -98,6 +98,8 @@ type Config struct {
 	Reranking RerankingConfig `yaml:"reranking" json:"reranking"`
 	// Magma configures optional multi-graph agentic memory support for RAG.
 	Magma MagmaConfig `yaml:"magma" json:"magma"`
+	// Archaeology configures decision lineage, artifact capture, and provenance.
+	Archaeology ArchaeologyConfig `yaml:"archaeology" json:"archaeology"`
 	// Memory coordinates evolving memory, belief memory, and MAGMA behind a
 	// single runtime toggle. The legacy top-level memory blocks remain accepted
 	// as aliases for compatibility.
@@ -165,6 +167,21 @@ type MemoryLLMClientsConfig struct {
 	Evolving           LLMClientConfig `yaml:"evolving" json:"evolving"`
 	BeliefDistillation LLMClientConfig `yaml:"beliefDistillation" json:"beliefDistillation"`
 	MagmaConsolidation LLMClientConfig `yaml:"magmaConsolidation" json:"magmaConsolidation"`
+}
+
+// ArchaeologyConfig controls context-archaeology memory features.
+type ArchaeologyConfig struct {
+	Enabled                 bool                     `yaml:"enabled" json:"enabled"`
+	ArchiveBeforeDelete     bool                     `yaml:"archive_before_delete" json:"archiveBeforeDelete"`
+	DecisionDistiller       bool                     `yaml:"decision_distiller" json:"decisionDistiller"`
+	CausalGroundingRequired bool                     `yaml:"causal_grounding_required" json:"causalGroundingRequired"`
+	Reactor                 ArchaeologyReactorConfig `yaml:"reactor" json:"reactor"`
+}
+
+// ArchaeologyReactorConfig tunes belief-to-decision stale detection.
+type ArchaeologyReactorConfig struct {
+	ConfidenceFloor     float64 `yaml:"confidence_floor" json:"confidenceFloor"`
+	ConfidenceDropDelta float64 `yaml:"confidence_drop_delta" json:"confidenceDropDelta"`
 }
 
 // PromptOverridesConfig customizes built-in prompt blocks.

--- a/internal/config/config_storage.go
+++ b/internal/config/config_storage.go
@@ -208,6 +208,8 @@ type MagmaLifecycleConfig struct {
 	MinSemanticWeight      float64 `yaml:"minSemanticWeight" json:"minSemanticWeight"`
 	LowConfidenceThreshold float64 `yaml:"lowConfidenceThreshold" json:"lowConfidenceThreshold"`
 	RequireReviewApproval  bool    `yaml:"requireReviewApproval" json:"requireReviewApproval"`
+	ArchiveBeforeDelete    bool    `yaml:"archiveBeforeDelete" json:"archiveBeforeDelete"`
+	RequireCausalGrounding bool    `yaml:"requireCausalGrounding" json:"requireCausalGrounding"`
 }
 
 // EmbeddingInstructionConfig configures query-side embedding instructions.

--- a/internal/config/loader_defaults.go
+++ b/internal/config/loader_defaults.go
@@ -13,12 +13,27 @@ func applyDefaults(cfg *Config) {
 	applyRuntimeDefaults(cfg)
 	applyCodeQADefaults(cfg)
 	applyBeliefDefaults(cfg)
+	applyArchaeologyDefaults(cfg)
 	applyCodeQAFallbackDefaults(cfg)
 	applyTimeoutAndTokenDefaults(cfg)
 	applyEmbeddingAndRerankingDefaults(cfg)
 	applyMCPAndDatabaseDefaults(cfg)
 	applyAuthAndTransitDefaults(cfg)
 	syncUnifiedMemoryConfig(cfg)
+}
+
+func applyArchaeologyDefaults(cfg *Config) {
+	if cfg.Archaeology.Reactor.ConfidenceFloor <= 0 {
+		cfg.Archaeology.Reactor.ConfidenceFloor = 0.35
+	}
+	if cfg.Archaeology.Reactor.ConfidenceDropDelta <= 0 {
+		cfg.Archaeology.Reactor.ConfidenceDropDelta = 0.30
+	}
+	if cfg.Archaeology.Enabled {
+		cfg.Archaeology.ArchiveBeforeDelete = true
+		cfg.Archaeology.DecisionDistiller = true
+		cfg.Archaeology.CausalGroundingRequired = true
+	}
 }
 
 func applyUnifiedMemoryAliases(cfg *Config) {
@@ -537,5 +552,9 @@ func applyMagmaDefaults(cfg *Config) {
 	}
 	if cfg.Magma.Lifecycle.LowConfidenceThreshold <= 0 {
 		cfg.Magma.Lifecycle.LowConfidenceThreshold = 0.6
+	}
+	if cfg.Archaeology.Enabled {
+		cfg.Magma.Lifecycle.ArchiveBeforeDelete = cfg.Archaeology.ArchiveBeforeDelete
+		cfg.Magma.Lifecycle.RequireCausalGrounding = cfg.Archaeology.CausalGroundingRequired
 	}
 }

--- a/internal/persistence/databases/artifact_store_memory.go
+++ b/internal/persistence/databases/artifact_store_memory.go
@@ -1,0 +1,137 @@
+package databases
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"maps"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"manifold/internal/agent/memory/artifact"
+
+	"github.com/google/uuid"
+)
+
+// NewMemoryArtifactStore returns an in-memory artifact store for local development and tests.
+func NewMemoryArtifactStore() artifact.Store {
+	return &memArtifactStore{artifacts: map[string]artifact.Artifact{}}
+}
+
+type memArtifactStore struct {
+	mu        sync.RWMutex
+	artifacts map[string]artifact.Artifact
+}
+
+func (s *memArtifactStore) Init(context.Context) error { return nil }
+
+func (s *memArtifactStore) UpsertArtifact(_ context.Context, item artifact.Artifact) (artifact.Artifact, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	item = prepareArtifact(item)
+	for id, existing := range s.artifacts {
+		if existing.TenantID == item.TenantID && existing.Kind == item.Kind && existing.ExternalID == item.ExternalID && existing.ContentHash == item.ContentHash {
+			item.ID = id
+			item.CapturedAt = existing.CapturedAt
+			s.artifacts[id] = cloneArtifact(item)
+			return cloneArtifact(item), nil
+		}
+	}
+	s.artifacts[item.ID] = cloneArtifact(item)
+	return cloneArtifact(item), nil
+}
+
+func (s *memArtifactStore) GetArtifact(_ context.Context, tenantID int64, id string) (artifact.Artifact, bool, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	item, ok := s.artifacts[strings.TrimSpace(id)]
+	if !ok || item.TenantID != normalizeTenantID(tenantID) {
+		return artifact.Artifact{}, false, nil
+	}
+	return cloneArtifact(item), true, nil
+}
+
+func (s *memArtifactStore) FindByExternalID(_ context.Context, tenantID int64, kind artifact.ArtifactKind, externalID string) ([]artifact.Artifact, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := []artifact.Artifact{}
+	for _, item := range s.artifacts {
+		if item.TenantID == normalizeTenantID(tenantID) && item.Kind == kind && item.ExternalID == strings.TrimSpace(externalID) {
+			out = append(out, cloneArtifact(item))
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].CapturedAt.Before(out[j].CapturedAt) })
+	return out, nil
+}
+
+func (s *memArtifactStore) SearchArtifacts(_ context.Context, query artifact.SearchQuery) ([]artifact.SearchResult, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	limit := query.Limit
+	if limit <= 0 {
+		limit = 10
+	}
+	tenantID := normalizeTenantID(query.TenantID)
+	kindSet := map[artifact.ArtifactKind]bool{}
+	for _, kind := range query.Kinds {
+		kindSet[kind] = true
+	}
+	needle := strings.ToLower(strings.TrimSpace(query.Query))
+	out := make([]artifact.SearchResult, 0, limit)
+	for _, item := range s.artifacts {
+		if item.TenantID != tenantID {
+			continue
+		}
+		if len(kindSet) > 0 && !kindSet[item.Kind] {
+			continue
+		}
+		text := strings.ToLower(item.Title + " " + item.Excerpt + " " + item.ExternalID)
+		if needle != "" && !strings.Contains(text, needle) {
+			continue
+		}
+		score := 1.0
+		if needle != "" {
+			score = 1.1
+		}
+		out = append(out, artifact.SearchResult{Artifact: cloneArtifact(item), Score: score})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Score == out[j].Score {
+			return out[i].Artifact.CapturedAt.After(out[j].Artifact.CapturedAt)
+		}
+		return out[i].Score > out[j].Score
+	})
+	if len(out) > limit {
+		out = out[:limit]
+	}
+	return out, nil
+}
+
+func prepareArtifact(item artifact.Artifact) artifact.Artifact {
+	item.TenantID = normalizeTenantID(item.TenantID)
+	if strings.TrimSpace(item.ID) == "" {
+		item.ID = uuid.NewString()
+	}
+	item.ExternalID = strings.TrimSpace(item.ExternalID)
+	item.URI = strings.TrimSpace(item.URI)
+	item.Title = strings.TrimSpace(item.Title)
+	item.Excerpt = strings.TrimSpace(item.Excerpt)
+	if item.ContentHash == "" {
+		sum := sha256.Sum256([]byte(item.Title + "\n" + item.Excerpt))
+		item.ContentHash = fmt.Sprintf("%x", sum)
+	}
+	if item.CapturedAt.IsZero() {
+		item.CapturedAt = time.Now().UTC()
+	}
+	if item.Metadata == nil {
+		item.Metadata = map[string]any{}
+	}
+	return item
+}
+
+func cloneArtifact(item artifact.Artifact) artifact.Artifact {
+	item.Metadata = maps.Clone(item.Metadata)
+	return item
+}

--- a/internal/persistence/databases/artifact_store_postgres.go
+++ b/internal/persistence/databases/artifact_store_postgres.go
@@ -1,0 +1,172 @@
+package databases
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+
+	"manifold/internal/agent/memory/artifact"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// NewPostgresArtifactStore returns the postgres artifact store.
+func NewPostgresArtifactStore(pool *pgxpool.Pool) artifact.Store {
+	if pool == nil {
+		return NewMemoryArtifactStore()
+	}
+	return &pgArtifactStore{pool: pool}
+}
+
+type pgArtifactStore struct {
+	pool *pgxpool.Pool
+}
+
+func (s *pgArtifactStore) Close() {
+	if s.pool != nil {
+		s.pool.Close()
+	}
+}
+
+func (s *pgArtifactStore) Init(ctx context.Context) error {
+	if s.pool == nil {
+		return errors.New("postgres artifact store requires pool")
+	}
+	_, err := s.pool.Exec(ctx, `
+CREATE TABLE IF NOT EXISTS artifact_records (
+	id TEXT PRIMARY KEY,
+	tenant_id BIGINT NOT NULL,
+	kind TEXT NOT NULL,
+	external_id TEXT NOT NULL,
+	uri TEXT NOT NULL DEFAULT '',
+	title TEXT NOT NULL DEFAULT '',
+	excerpt TEXT NOT NULL DEFAULT '',
+	content_hash TEXT NOT NULL,
+	authored_by TEXT NOT NULL DEFAULT '',
+	authored_at TIMESTAMPTZ,
+	captured_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+	metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+	payload JSONB NOT NULL DEFAULT '{}'::jsonb,
+	search_tsv tsvector GENERATED ALWAYS AS (
+		to_tsvector('simple', coalesce(title, '') || ' ' || coalesce(excerpt, '') || ' ' || coalesce(external_id, ''))
+	) STORED
+);
+CREATE UNIQUE INDEX IF NOT EXISTS artifact_records_immutable_source
+	ON artifact_records(tenant_id, kind, external_id, content_hash);
+CREATE INDEX IF NOT EXISTS artifact_records_external_id
+	ON artifact_records(tenant_id, kind, external_id);
+CREATE INDEX IF NOT EXISTS artifact_records_search_tsv_idx
+	ON artifact_records USING GIN(search_tsv);
+`)
+	return err
+}
+
+func (s *pgArtifactStore) UpsertArtifact(ctx context.Context, item artifact.Artifact) (artifact.Artifact, error) {
+	item = prepareArtifact(item)
+	if existingID, ok, err := s.findBySourceHash(ctx, item); err != nil {
+		return artifact.Artifact{}, err
+	} else if ok {
+		item.ID = existingID
+	}
+	payload, err := json.Marshal(item)
+	if err != nil {
+		return artifact.Artifact{}, err
+	}
+	metadata, err := json.Marshal(item.Metadata)
+	if err != nil {
+		return artifact.Artifact{}, err
+	}
+	_, err = s.pool.Exec(ctx, `
+INSERT INTO artifact_records(id, tenant_id, kind, external_id, uri, title, excerpt, content_hash, authored_by, authored_at, captured_at, metadata, payload)
+VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12::jsonb, $13::jsonb)
+ON CONFLICT(id) DO UPDATE SET
+	uri=EXCLUDED.uri,
+	title=EXCLUDED.title,
+	excerpt=EXCLUDED.excerpt,
+	authored_by=EXCLUDED.authored_by,
+	authored_at=EXCLUDED.authored_at,
+	captured_at=EXCLUDED.captured_at,
+	metadata=EXCLUDED.metadata,
+	payload=EXCLUDED.payload
+`, item.ID, item.TenantID, item.Kind, item.ExternalID, item.URI, item.Title, item.Excerpt, item.ContentHash, item.AuthoredBy, item.AuthoredAt, item.CapturedAt, string(metadata), string(payload))
+	if err != nil {
+		return artifact.Artifact{}, err
+	}
+	return cloneArtifact(item), nil
+}
+
+func (s *pgArtifactStore) GetArtifact(ctx context.Context, tenantID int64, id string) (artifact.Artifact, bool, error) {
+	row := s.pool.QueryRow(ctx, `SELECT payload FROM artifact_records WHERE tenant_id = $1 AND id = $2`, normalizeTenantID(tenantID), strings.TrimSpace(id))
+	item, ok, err := scanPGJSONRow[artifact.Artifact](row)
+	if err != nil || !ok {
+		return artifact.Artifact{}, ok, err
+	}
+	return cloneArtifact(item), true, nil
+}
+
+func (s *pgArtifactStore) FindByExternalID(ctx context.Context, tenantID int64, kind artifact.ArtifactKind, externalID string) ([]artifact.Artifact, error) {
+	rows, err := s.pool.Query(ctx, `
+SELECT payload FROM artifact_records
+WHERE tenant_id = $1 AND kind = $2 AND external_id = $3
+ORDER BY captured_at ASC
+`, normalizeTenantID(tenantID), kind, strings.TrimSpace(externalID))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items, err := scanPGJSONRows[artifact.Artifact](rows)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]artifact.Artifact, 0, len(items))
+	for _, item := range items {
+		out = append(out, cloneArtifact(item))
+	}
+	return out, nil
+}
+
+func (s *pgArtifactStore) SearchArtifacts(ctx context.Context, query artifact.SearchQuery) ([]artifact.SearchResult, error) {
+	limit := normalizedLimit(query.Limit, 10)
+	kinds := make([]string, 0, len(query.Kinds))
+	for _, kind := range query.Kinds {
+		kinds = append(kinds, string(kind))
+	}
+	needle := strings.TrimSpace(query.Query)
+	rows, err := s.pool.Query(ctx, `
+SELECT payload,
+	1 + CASE WHEN $3 = '' THEN 0 ELSE ts_rank(search_tsv, plainto_tsquery('simple', $3)) END AS score
+FROM artifact_records
+WHERE tenant_id = $1
+	AND (cardinality($2::text[]) = 0 OR kind = ANY($2::text[]))
+	AND ($3 = '' OR search_tsv @@ plainto_tsquery('simple', $3) OR title ILIKE '%' || $3 || '%' OR excerpt ILIKE '%' || $3 || '%' OR external_id ILIKE '%' || $3 || '%')
+ORDER BY score DESC, captured_at DESC
+LIMIT $4
+`, normalizeTenantID(query.TenantID), kinds, needle, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := make([]artifact.SearchResult, 0, limit)
+	for rows.Next() {
+		item, score, err := scanPGJSONWithScore[artifact.Artifact](rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, artifact.SearchResult{Artifact: cloneArtifact(item), Score: score})
+	}
+	return out, rows.Err()
+}
+
+func (s *pgArtifactStore) findBySourceHash(ctx context.Context, item artifact.Artifact) (string, bool, error) {
+	var id string
+	err := s.pool.QueryRow(ctx, `
+SELECT id FROM artifact_records
+WHERE tenant_id = $1 AND kind = $2 AND external_id = $3 AND content_hash = $4
+`, item.TenantID, item.Kind, item.ExternalID, item.ContentHash).Scan(&id)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return "", false, nil
+	}
+	return id, err == nil, err
+}

--- a/internal/persistence/databases/artifact_store_sqlite.go
+++ b/internal/persistence/databases/artifact_store_sqlite.go
@@ -1,0 +1,182 @@
+package databases
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"sort"
+	"strings"
+
+	"manifold/internal/agent/memory/artifact"
+)
+
+type sqliteArtifactStore struct {
+	db *sql.DB
+}
+
+// NewSQLiteArtifactStore returns a SQLite-backed artifact store.
+func NewSQLiteArtifactStore(db *sql.DB) artifact.Store {
+	if db == nil {
+		return NewMemoryArtifactStore()
+	}
+	return &sqliteArtifactStore{db: db}
+}
+
+func (s *sqliteArtifactStore) Init(ctx context.Context) error {
+	if s.db == nil {
+		return errors.New("sqlite artifact store requires db")
+	}
+	_, err := s.db.ExecContext(ctx, `
+CREATE TABLE IF NOT EXISTS artifact_records (
+	id TEXT PRIMARY KEY,
+	tenant_id INTEGER NOT NULL,
+	kind TEXT NOT NULL,
+	external_id TEXT NOT NULL,
+	uri TEXT NOT NULL DEFAULT '',
+	title TEXT NOT NULL DEFAULT '',
+	excerpt TEXT NOT NULL DEFAULT '',
+	content_hash TEXT NOT NULL,
+	authored_by TEXT NOT NULL DEFAULT '',
+	authored_at DATETIME,
+	captured_at DATETIME NOT NULL,
+	metadata TEXT,
+	payload TEXT NOT NULL CHECK(json_valid(payload))
+);
+CREATE UNIQUE INDEX IF NOT EXISTS artifact_records_immutable_source
+	ON artifact_records(tenant_id, kind, external_id, content_hash);
+CREATE INDEX IF NOT EXISTS artifact_records_external_id
+	ON artifact_records(tenant_id, kind, external_id);
+`)
+	return err
+}
+
+func (s *sqliteArtifactStore) UpsertArtifact(ctx context.Context, item artifact.Artifact) (artifact.Artifact, error) {
+	if err := s.Init(ctx); err != nil {
+		return artifact.Artifact{}, err
+	}
+	item = prepareArtifact(item)
+	if existingID, ok, err := s.findBySourceHash(ctx, item); err != nil {
+		return artifact.Artifact{}, err
+	} else if ok {
+		item.ID = existingID
+	}
+	payload, err := json.Marshal(item)
+	if err != nil {
+		return artifact.Artifact{}, err
+	}
+	metadata, _ := json.Marshal(item.Metadata)
+	_, err = s.db.ExecContext(ctx, `
+INSERT INTO artifact_records(id, tenant_id, kind, external_id, uri, title, excerpt, content_hash, authored_by, authored_at, captured_at, metadata, payload)
+VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT(id) DO UPDATE SET
+	uri=excluded.uri,
+	title=excluded.title,
+	excerpt=excluded.excerpt,
+	authored_by=excluded.authored_by,
+	authored_at=excluded.authored_at,
+	captured_at=excluded.captured_at,
+	metadata=excluded.metadata,
+	payload=excluded.payload
+`, item.ID, item.TenantID, item.Kind, item.ExternalID, item.URI, item.Title, item.Excerpt, item.ContentHash, item.AuthoredBy, sqliteTime{Time: item.AuthoredAt}, sqliteTime{Time: item.CapturedAt}, string(metadata), string(payload))
+	if err != nil {
+		return artifact.Artifact{}, err
+	}
+	return cloneArtifact(item), nil
+}
+
+func (s *sqliteArtifactStore) GetArtifact(ctx context.Context, tenantID int64, id string) (artifact.Artifact, bool, error) {
+	if err := s.Init(ctx); err != nil {
+		return artifact.Artifact{}, false, err
+	}
+	row := s.db.QueryRowContext(ctx, `SELECT payload FROM artifact_records WHERE tenant_id = ? AND id = ?`, normalizeTenantID(tenantID), strings.TrimSpace(id))
+	item, ok, err := scanJSONRow[artifact.Artifact](row)
+	if err != nil || !ok {
+		return artifact.Artifact{}, ok, err
+	}
+	return cloneArtifact(item), true, nil
+}
+
+func (s *sqliteArtifactStore) FindByExternalID(ctx context.Context, tenantID int64, kind artifact.ArtifactKind, externalID string) ([]artifact.Artifact, error) {
+	if err := s.Init(ctx); err != nil {
+		return nil, err
+	}
+	rows, err := s.db.QueryContext(ctx, `SELECT payload FROM artifact_records WHERE tenant_id = ? AND kind = ? AND external_id = ? ORDER BY captured_at ASC`, normalizeTenantID(tenantID), kind, strings.TrimSpace(externalID))
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	out := []artifact.Artifact{}
+	for rows.Next() {
+		item, err := scanJSONRows[artifact.Artifact](rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, cloneArtifact(item))
+	}
+	return out, rows.Err()
+}
+
+func (s *sqliteArtifactStore) SearchArtifacts(ctx context.Context, query artifact.SearchQuery) ([]artifact.SearchResult, error) {
+	if err := s.Init(ctx); err != nil {
+		return nil, err
+	}
+	rows, err := s.db.QueryContext(ctx, `SELECT payload FROM artifact_records WHERE tenant_id = ?`, normalizeTenantID(query.TenantID))
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	kindSet := map[artifact.ArtifactKind]bool{}
+	for _, kind := range query.Kinds {
+		kindSet[kind] = true
+	}
+	needle := strings.ToLower(strings.TrimSpace(query.Query))
+	limit := query.Limit
+	if limit <= 0 {
+		limit = 10
+	}
+	out := []artifact.SearchResult{}
+	for rows.Next() {
+		item, err := scanJSONRows[artifact.Artifact](rows)
+		if err != nil {
+			return nil, err
+		}
+		if len(kindSet) > 0 && !kindSet[item.Kind] {
+			continue
+		}
+		text := strings.ToLower(item.Title + " " + item.Excerpt + " " + item.ExternalID)
+		if needle != "" && !strings.Contains(text, needle) {
+			continue
+		}
+		score := 1.0
+		if needle != "" {
+			score = 1.1
+		}
+		out = append(out, artifact.SearchResult{Artifact: cloneArtifact(item), Score: score})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Score == out[j].Score {
+			return out[i].Artifact.CapturedAt.After(out[j].Artifact.CapturedAt)
+		}
+		return out[i].Score > out[j].Score
+	})
+	if len(out) > limit {
+		out = out[:limit]
+	}
+	return out, nil
+}
+
+func (s *sqliteArtifactStore) findBySourceHash(ctx context.Context, item artifact.Artifact) (string, bool, error) {
+	var id string
+	err := s.db.QueryRowContext(ctx, `
+SELECT id FROM artifact_records
+WHERE tenant_id = ? AND kind = ? AND external_id = ? AND content_hash = ?`,
+		item.TenantID, item.Kind, item.ExternalID, item.ContentHash).Scan(&id)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", false, nil
+	}
+	return id, err == nil, err
+}

--- a/internal/persistence/databases/chat_store_helpers.go
+++ b/internal/persistence/databases/chat_store_helpers.go
@@ -2,6 +2,7 @@ package databases
 
 import (
 	"context"
+	"database/sql"
 	"strings"
 
 	"manifold/internal/persistence"
@@ -27,4 +28,19 @@ func snippetForPreview(content string) string {
 		return trimmed
 	}
 	return trimmed[:maxLen]
+}
+
+func nullableInt64Value(value *int64) any {
+	if value == nil {
+		return nil
+	}
+	return *value
+}
+
+func int64PtrFromNull(value sql.NullInt64) *int64 {
+	if !value.Valid {
+		return nil
+	}
+	out := value.Int64
+	return &out
 }

--- a/internal/persistence/databases/chat_store_memory.go
+++ b/internal/persistence/databases/chat_store_memory.go
@@ -51,6 +51,11 @@ func copyUserID(id *int64) *int64 {
 	return &v
 }
 
+func (s *memChatStore) sessionWithMessageCountLocked(sess persistence.ChatSession) persistence.ChatSession {
+	sess.MessageCount = len(s.messages[sess.ID])
+	return sess
+}
+
 func normalizeChatSessionKind(kind string) string {
 	kind = strings.TrimSpace(kind)
 	if kind == "" {
@@ -81,13 +86,13 @@ func (s *memChatStore) EnsureSessionKind(ctx context.Context, userID *int64, id,
 			sess.Kind = persistence.ChatSessionKindChat
 			s.sessions[id] = sess
 		}
-		return sess, nil
+		return s.sessionWithMessageCountLocked(sess), nil
 	}
 	now := time.Now().UTC()
 	sess := newChatSession(id, userID, name, kind, now)
 	s.sessions[id] = sess
 	s.messages[id] = nil
-	return sess, nil
+	return s.sessionWithMessageCountLocked(sess), nil
 }
 
 func (s *memChatStore) ListSessions(ctx context.Context, userID *int64) ([]persistence.ChatSession, error) {
@@ -106,7 +111,7 @@ func (s *memChatStore) ListSessionsByKind(ctx context.Context, userID *int64, ki
 		if normalizeChatSessionKind(sess.Kind) != kind {
 			continue
 		}
-		out = append(out, sess)
+		out = append(out, s.sessionWithMessageCountLocked(sess))
 	}
 	sort.Slice(out, func(i, j int) bool {
 		if out[i].UpdatedAt.Equal(out[j].UpdatedAt) {
@@ -127,7 +132,7 @@ func (s *memChatStore) GetSession(ctx context.Context, userID *int64, id string)
 	if !hasAccess(userID, sess.UserID) {
 		return persistence.ChatSession{}, persistence.ErrForbidden
 	}
-	return sess, nil
+	return s.sessionWithMessageCountLocked(sess), nil
 }
 
 func (s *memChatStore) CreateSession(ctx context.Context, userID *int64, name string) (persistence.ChatSession, error) {
@@ -146,7 +151,7 @@ func (s *memChatStore) CreateSessionKind(ctx context.Context, userID *int64, nam
 	sess := newChatSession(id, userID, name, kind, now)
 	s.sessions[id] = sess
 	s.messages[id] = nil
-	return sess, nil
+	return s.sessionWithMessageCountLocked(sess), nil
 }
 
 func (s *memChatStore) RenameSession(ctx context.Context, userID *int64, id, name string) (persistence.ChatSession, error) {
@@ -165,7 +170,7 @@ func (s *memChatStore) RenameSession(ctx context.Context, userID *int64, id, nam
 	sess.Name = name
 	sess.UpdatedAt = time.Now().UTC()
 	s.sessions[id] = sess
-	return sess, nil
+	return s.sessionWithMessageCountLocked(sess), nil
 }
 
 func (s *memChatStore) SetSessionProject(ctx context.Context, userID *int64, id, projectID string) (persistence.ChatSession, error) {
@@ -181,7 +186,7 @@ func (s *memChatStore) SetSessionProject(ctx context.Context, userID *int64, id,
 	sess.ProjectID = strings.TrimSpace(projectID)
 	sess.UpdatedAt = time.Now().UTC()
 	s.sessions[id] = sess
-	return sess, nil
+	return s.sessionWithMessageCountLocked(sess), nil
 }
 
 func (s *memChatStore) SetSessionMemorySettings(ctx context.Context, userID *int64, id string, memoryEnabled bool, evolvingMemoryEnabled bool, beliefMemoryEnabled bool) (persistence.ChatSession, error) {
@@ -199,7 +204,7 @@ func (s *memChatStore) SetSessionMemorySettings(ctx context.Context, userID *int
 	sess.BeliefMemoryEnabled = memoryEnabled
 	sess.UpdatedAt = time.Now().UTC()
 	s.sessions[id] = sess
-	return sess, nil
+	return s.sessionWithMessageCountLocked(sess), nil
 }
 
 func (s *memChatStore) DeleteSession(ctx context.Context, userID *int64, id string) error {

--- a/internal/persistence/databases/chat_store_memory_test.go
+++ b/internal/persistence/databases/chat_store_memory_test.go
@@ -23,6 +23,9 @@ func TestMemChatStoreLifecycle(t *testing.T) {
 	if sess.ID != "session-1" {
 		t.Fatalf("unexpected session id: %s", sess.ID)
 	}
+	if sess.MessageCount != 0 {
+		t.Fatalf("new session should have 0 messages, got %d", sess.MessageCount)
+	}
 	if sess.MemoryEnabled || sess.EvolvingMemoryEnabled || sess.BeliefMemoryEnabled {
 		t.Fatalf("new sessions should default unified memory off, got memory=%v evolving=%v belief=%v", sess.MemoryEnabled, sess.EvolvingMemoryEnabled, sess.BeliefMemoryEnabled)
 	}
@@ -31,9 +34,10 @@ func TestMemChatStoreLifecycle(t *testing.T) {
 		t.Fatalf("AppendMessages with empty slice: %v", err)
 	}
 
+	durationMs := int64(1200)
 	if err := store.AppendMessages(ctx, nil, "session-1", []persistence.ChatMessage{
 		{Role: "user", Content: "Hello", CreatedAt: time.Now()},
-		{Role: "assistant", Content: "Hi there", CreatedAt: time.Now().Add(time.Second)},
+		{Role: "assistant", Content: "Hi there", CreatedAt: time.Now().Add(time.Second), DurationMs: &durationMs},
 	}, "Hi there", "test-model"); err != nil {
 		t.Fatalf("AppendMessages: %v", err)
 	}
@@ -47,6 +51,9 @@ func TestMemChatStoreLifecycle(t *testing.T) {
 	}
 	if msgs[0].Role != "user" || msgs[1].Role != "assistant" {
 		t.Fatalf("unexpected roles: %#v", msgs)
+	}
+	if msgs[1].DurationMs == nil || *msgs[1].DurationMs != durationMs {
+		t.Fatalf("expected assistant duration to round trip, got %#v", msgs[1].DurationMs)
 	}
 	limited, err := store.ListMessages(ctx, nil, "session-1", 1)
 	if err != nil {
@@ -65,6 +72,9 @@ func TestMemChatStoreLifecycle(t *testing.T) {
 	if updated.Summary != "summary" || updated.SummarizedCount != 2 {
 		t.Fatalf("unexpected summary state: %#v", updated)
 	}
+	if updated.MessageCount != 2 {
+		t.Fatalf("expected message count 2 after append, got %d", updated.MessageCount)
+	}
 
 	sessions, err := store.ListSessions(ctx, nil)
 	if err != nil {
@@ -76,12 +86,23 @@ func TestMemChatStoreLifecycle(t *testing.T) {
 	if sessions[0].LastMessagePreview != "Hi there" {
 		t.Fatalf("unexpected preview: %s", sessions[0].LastMessagePreview)
 	}
+	if sessions[0].MessageCount != 2 {
+		t.Fatalf("expected listed message count 2, got %d", sessions[0].MessageCount)
+	}
 
-	if _, err := store.RenameSession(ctx, nil, "session-1", "Updated"); err != nil {
+	renamed, err := store.RenameSession(ctx, nil, "session-1", "Updated")
+	if err != nil {
 		t.Fatalf("RenameSession: %v", err)
 	}
-	if _, err := store.SetSessionProject(ctx, nil, "session-1", "project-1"); err != nil {
+	if renamed.MessageCount != 2 {
+		t.Fatalf("expected renamed session message count 2, got %d", renamed.MessageCount)
+	}
+	projectSession, err := store.SetSessionProject(ctx, nil, "session-1", "project-1")
+	if err != nil {
 		t.Fatalf("SetSessionProject: %v", err)
+	}
+	if projectSession.MessageCount != 2 {
+		t.Fatalf("expected project session message count 2, got %d", projectSession.MessageCount)
 	}
 	locked, err := store.GetSession(ctx, nil, "session-1")
 	if err != nil {
@@ -142,8 +163,16 @@ func TestMemChatStoreOwnership(t *testing.T) {
 		t.Fatalf("expected ErrForbidden list messages, got %v", err)
 	}
 
-	if _, err := store.GetSession(ctx, nil, sess.ID); err != nil {
+	if err := store.AppendMessages(ctx, user1, sess.ID, []persistence.ChatMessage{{Role: "user", Content: "owned"}}, "owned", ""); err != nil {
+		t.Fatalf("AppendMessages owner: %v", err)
+	}
+
+	adminSession, err := store.GetSession(ctx, nil, sess.ID)
+	if err != nil {
 		t.Fatalf("admin (nil user) should access session: %v", err)
+	}
+	if adminSession.MessageCount != 1 {
+		t.Fatalf("expected admin to see owner message count 1, got %d", adminSession.MessageCount)
 	}
 }
 
@@ -233,6 +262,9 @@ func TestMemChatStoreDeleteMessageWithRelated(t *testing.T) {
 	}
 	if sess.Summary != "" || sess.SummarizedCount != 0 {
 		t.Fatalf("expected cleared summary, got %#v", sess)
+	}
+	if sess.MessageCount != 2 {
+		t.Fatalf("expected message count 2 after related delete, got %d", sess.MessageCount)
 	}
 	if sess.LastMessagePreview != "done" {
 		t.Fatalf("expected preview to follow remaining tail, got %q", sess.LastMessagePreview)

--- a/internal/persistence/databases/chat_store_postgres.go
+++ b/internal/persistence/databases/chat_store_postgres.go
@@ -51,7 +51,8 @@ CREATE TABLE IF NOT EXISTS chat_messages (
     session_id UUID NOT NULL REFERENCES chat_sessions(id) ON DELETE CASCADE,
     role TEXT NOT NULL,
     content TEXT NOT NULL,
-    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    duration_ms BIGINT NULL
 );
 
 CREATE INDEX IF NOT EXISTS chat_messages_session_created_idx ON chat_messages(session_id, created_at);
@@ -79,6 +80,9 @@ ALTER TABLE chat_sessions
 
 ALTER TABLE chat_sessions
     ADD COLUMN IF NOT EXISTS belief_memory_enabled BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE chat_messages
+    ADD COLUMN IF NOT EXISTS duration_ms BIGINT NULL;
 
 ALTER TABLE chat_sessions
     ALTER COLUMN memory_enabled SET DEFAULT FALSE;

--- a/internal/persistence/databases/chat_store_postgres_messages.go
+++ b/internal/persistence/databases/chat_store_postgres_messages.go
@@ -2,6 +2,7 @@ package databases
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"strings"
 	"time"
@@ -140,15 +141,15 @@ func (s *pgChatStore) ListMessages(ctx context.Context, userID *int64, sessionID
 	}
 	log.Debug().Str("session_id", sessionID).Msg("list_messages_session_ok")
 	query := `
-SELECT id, session_id, role, content, created_at
+SELECT id, session_id, role, content, created_at, duration_ms
 FROM chat_messages
 WHERE session_id = $1
 ORDER BY created_at ASC, id ASC`
 	args := []any{sessionID}
 	if limit > 0 {
 		query = `
-SELECT id, session_id, role, content, created_at FROM (
-    SELECT id, session_id, role, content, created_at
+SELECT id, session_id, role, content, created_at, duration_ms FROM (
+    SELECT id, session_id, role, content, created_at, duration_ms
     FROM chat_messages
     WHERE session_id = $1
     ORDER BY created_at DESC, id DESC
@@ -165,9 +166,11 @@ ORDER BY created_at ASC, id ASC`
 	var out []persistence.ChatMessage
 	for rows.Next() {
 		var msg persistence.ChatMessage
-		if err := rows.Scan(&msg.ID, &msg.SessionID, &msg.Role, &msg.Content, &msg.CreatedAt); err != nil {
+		var duration sql.NullInt64
+		if err := rows.Scan(&msg.ID, &msg.SessionID, &msg.Role, &msg.Content, &msg.CreatedAt, &duration); err != nil {
 			return nil, err
 		}
+		msg.DurationMs = int64PtrFromNull(duration)
 		out = append(out, msg)
 	}
 	if out == nil {
@@ -211,13 +214,13 @@ func (s *pgChatStore) appendMessages(req chatAppendMessagesRequest) error {
 			createdAt = time.Now().UTC()
 		}
 		query := `
-	INSERT INTO chat_messages (id, session_id, role, content, created_at)
-	VALUES ($1, $2, $3, $4, $5)`
+		INSERT INTO chat_messages (id, session_id, role, content, created_at, duration_ms)
+	VALUES ($1, $2, $3, $4, $5, $6)`
 		if req.skipExisting {
 			query += `
 	ON CONFLICT (id) DO NOTHING`
 		}
-		if _, err := tx.Exec(ctx, query, id, req.sessionID, message.Role, message.Content, createdAt); err != nil {
+		if _, err := tx.Exec(ctx, query, id, req.sessionID, message.Role, message.Content, createdAt, nullableInt64Value(message.DurationMs)); err != nil {
 			return err
 		}
 	}

--- a/internal/persistence/databases/chat_store_postgres_sessions.go
+++ b/internal/persistence/databases/chat_store_postgres_sessions.go
@@ -26,7 +26,7 @@ func hasAccess(userID *int64, owner *int64) bool {
 func (s *pgChatStore) scanSession(row pgx.Row) (persistence.ChatSession, error) {
 	var cs persistence.ChatSession
 	var owner sql.NullInt64
-	if err := row.Scan(&cs.ID, &cs.Name, &cs.Kind, &owner, &cs.CreatedAt, &cs.UpdatedAt, &cs.LastMessagePreview, &cs.Model, &cs.Summary, &cs.SummarizedCount, &cs.ProjectID, &cs.MemoryEnabled, &cs.EvolvingMemoryEnabled, &cs.BeliefMemoryEnabled); err != nil {
+	if err := row.Scan(&cs.ID, &cs.Name, &cs.Kind, &owner, &cs.CreatedAt, &cs.UpdatedAt, &cs.LastMessagePreview, &cs.MessageCount, &cs.Model, &cs.Summary, &cs.SummarizedCount, &cs.ProjectID, &cs.MemoryEnabled, &cs.EvolvingMemoryEnabled, &cs.BeliefMemoryEnabled); err != nil {
 		return persistence.ChatSession{}, err
 	}
 	if cs.Kind == "" {
@@ -84,11 +84,14 @@ WITH ins AS (
   INSERT INTO chat_sessions (id, user_id, name, kind)
   VALUES ($1, $2, $3, $4)
   ON CONFLICT (id) DO NOTHING
-  RETURNING id, name, kind, user_id, created_at, updated_at, last_message_preview, model, summary, summarized_count, project_id, memory_enabled, evolving_memory_enabled, belief_memory_enabled
+  RETURNING id, name, kind, user_id, created_at, updated_at, last_message_preview, 0::int AS message_count, model, summary, summarized_count, project_id, memory_enabled, evolving_memory_enabled, belief_memory_enabled
 )
-SELECT id, name, kind, user_id, created_at, updated_at, last_message_preview, model, summary, summarized_count, project_id, memory_enabled, evolving_memory_enabled, belief_memory_enabled FROM ins
+SELECT id, name, kind, user_id, created_at, updated_at, last_message_preview, message_count, model, summary, summarized_count, project_id, memory_enabled, evolving_memory_enabled, belief_memory_enabled FROM ins
 UNION ALL
-SELECT id, name, kind, user_id, created_at, updated_at, last_message_preview, model, summary, summarized_count, project_id, memory_enabled, evolving_memory_enabled, belief_memory_enabled FROM chat_sessions WHERE id = $1
+SELECT id, name, kind, user_id, created_at, updated_at, last_message_preview,
+	(SELECT COUNT(*)::int FROM chat_messages m WHERE m.session_id = chat_sessions.id) AS message_count,
+	model, summary, summarized_count, project_id, memory_enabled, evolving_memory_enabled, belief_memory_enabled
+FROM chat_sessions WHERE id = $1
 LIMIT 1`, id, uid, name, kind)
 	cs, err := s.scanSession(row)
 	if err != nil {
@@ -107,7 +110,9 @@ func (s *pgChatStore) ListSessions(ctx context.Context, userID *int64) ([]persis
 func (s *pgChatStore) ListSessionsByKind(ctx context.Context, userID *int64, kind string) ([]persistence.ChatSession, error) {
 	kind = normalizeSessionKind(kind)
 	query := `
-	SELECT id, name, kind, user_id, created_at, updated_at, last_message_preview, model, summary, summarized_count, project_id, memory_enabled, evolving_memory_enabled, belief_memory_enabled
+	SELECT id, name, kind, user_id, created_at, updated_at, last_message_preview,
+		(SELECT COUNT(*)::int FROM chat_messages m WHERE m.session_id = chat_sessions.id) AS message_count,
+		model, summary, summarized_count, project_id, memory_enabled, evolving_memory_enabled, belief_memory_enabled
 	FROM chat_sessions
 	WHERE kind = $1`
 	args := []any{kind}
@@ -145,7 +150,9 @@ ORDER BY updated_at DESC, created_at DESC`
 func (s *pgChatStore) GetSession(ctx context.Context, userID *int64, id string) (persistence.ChatSession, error) {
 	log := observability.LoggerWithTrace(ctx)
 	query := `
-SELECT id, name, kind, user_id, created_at, updated_at, last_message_preview, model, summary, summarized_count, project_id, memory_enabled, evolving_memory_enabled, belief_memory_enabled
+SELECT id, name, kind, user_id, created_at, updated_at, last_message_preview,
+	(SELECT COUNT(*)::int FROM chat_messages m WHERE m.session_id = chat_sessions.id) AS message_count,
+	model, summary, summarized_count, project_id, memory_enabled, evolving_memory_enabled, belief_memory_enabled
 FROM chat_sessions
 WHERE id = $1`
 	args := []any{id}
@@ -197,7 +204,7 @@ func (s *pgChatStore) CreateSessionKind(ctx context.Context, userID *int64, name
 	row := s.pool.QueryRow(ctx, `
 	INSERT INTO chat_sessions (id, user_id, name, kind)
 	VALUES ($1, $2, $3, $4)
-	RETURNING id, name, kind, user_id, created_at, updated_at, last_message_preview, model, summary, summarized_count, project_id, memory_enabled, evolving_memory_enabled, belief_memory_enabled`, id, uid, name, kind)
+	RETURNING id, name, kind, user_id, created_at, updated_at, last_message_preview, 0::int AS message_count, model, summary, summarized_count, project_id, memory_enabled, evolving_memory_enabled, belief_memory_enabled`, id, uid, name, kind)
 	return s.scanSession(row)
 }
 
@@ -215,7 +222,9 @@ WHERE id = $1`
 		args = append(args, *userID)
 	}
 	query += `
-RETURNING id, name, kind, user_id, created_at, updated_at, last_message_preview, model, summary, summarized_count, project_id, memory_enabled, evolving_memory_enabled, belief_memory_enabled`
+RETURNING id, name, kind, user_id, created_at, updated_at, last_message_preview,
+	(SELECT COUNT(*)::int FROM chat_messages m WHERE m.session_id = chat_sessions.id) AS message_count,
+	model, summary, summarized_count, project_id, memory_enabled, evolving_memory_enabled, belief_memory_enabled`
 	row := s.pool.QueryRow(ctx, query, args...)
 	cs, err := s.scanSession(row)
 	if err == nil {
@@ -249,7 +258,9 @@ WHERE id = $1`
 		args = append(args, *userID)
 	}
 	query += `
-RETURNING id, name, kind, user_id, created_at, updated_at, last_message_preview, model, summary, summarized_count, project_id, memory_enabled, evolving_memory_enabled, belief_memory_enabled`
+RETURNING id, name, kind, user_id, created_at, updated_at, last_message_preview,
+	(SELECT COUNT(*)::int FROM chat_messages m WHERE m.session_id = chat_sessions.id) AS message_count,
+	model, summary, summarized_count, project_id, memory_enabled, evolving_memory_enabled, belief_memory_enabled`
 	row := s.pool.QueryRow(ctx, query, args...)
 	cs, err := s.scanSession(row)
 	if err == nil {
@@ -282,7 +293,9 @@ WHERE id = $1`
 		args = append(args, *userID)
 	}
 	query += `
-RETURNING id, name, kind, user_id, created_at, updated_at, last_message_preview, model, summary, summarized_count, project_id, memory_enabled, evolving_memory_enabled, belief_memory_enabled`
+RETURNING id, name, kind, user_id, created_at, updated_at, last_message_preview,
+	(SELECT COUNT(*)::int FROM chat_messages m WHERE m.session_id = chat_sessions.id) AS message_count,
+	model, summary, summarized_count, project_id, memory_enabled, evolving_memory_enabled, belief_memory_enabled`
 	row := s.pool.QueryRow(ctx, query, args...)
 	cs, err := s.scanSession(row)
 	if err == nil {

--- a/internal/persistence/databases/chat_store_sqlite.go
+++ b/internal/persistence/databases/chat_store_sqlite.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 	"strings"
 	"time"
 
@@ -55,13 +56,17 @@ CREATE TABLE IF NOT EXISTS chat_messages (
 	session_id TEXT NOT NULL REFERENCES chat_sessions(id) ON DELETE CASCADE,
 	role TEXT NOT NULL,
 	content TEXT NOT NULL,
-	created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+	created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	duration_ms INTEGER NULL
 );
 CREATE INDEX IF NOT EXISTS chat_messages_session_created_idx ON chat_messages(session_id, created_at);
 CREATE INDEX IF NOT EXISTS chat_sessions_user_updated_idx ON chat_sessions(user_id, updated_at DESC);
 CREATE INDEX IF NOT EXISTS chat_sessions_user_created_idx ON chat_sessions(user_id, created_at DESC);
 `)
-	return err
+	if err != nil {
+		return err
+	}
+	return ensureSQLiteColumn(ctx, s.db, "chat_messages", "duration_ms", "INTEGER NULL")
 }
 
 func (s *sqliteChatStore) EnsureSession(ctx context.Context, userID *int64, id string, name string) (persistence.ChatSession, error) {
@@ -99,7 +104,10 @@ func (s *sqliteChatStore) ListSessionsByKind(ctx context.Context, userID *int64,
 		return nil, err
 	}
 	kind = normalizeSessionKind(kind)
-	query := `SELECT id, name, kind, user_id, created_at, updated_at, last_message_preview, model, summary, summarized_count, project_id, memory_enabled, evolving_memory_enabled, belief_memory_enabled FROM chat_sessions WHERE kind = ?`
+	query := `SELECT id, name, kind, user_id, created_at, updated_at, last_message_preview,
+		(SELECT COUNT(*) FROM chat_messages m WHERE m.session_id = chat_sessions.id) AS message_count,
+		model, summary, summarized_count, project_id, memory_enabled, evolving_memory_enabled, belief_memory_enabled
+		FROM chat_sessions WHERE kind = ?`
 	args := []any{kind}
 	if userID != nil {
 		query += ` AND user_id = ?`
@@ -126,7 +134,10 @@ func (s *sqliteChatStore) GetSession(ctx context.Context, userID *int64, id stri
 	if err := s.Init(ctx); err != nil {
 		return persistence.ChatSession{}, err
 	}
-	query := `SELECT id, name, kind, user_id, created_at, updated_at, last_message_preview, model, summary, summarized_count, project_id, memory_enabled, evolving_memory_enabled, belief_memory_enabled FROM chat_sessions WHERE id = ?`
+	query := `SELECT id, name, kind, user_id, created_at, updated_at, last_message_preview,
+		(SELECT COUNT(*) FROM chat_messages m WHERE m.session_id = chat_sessions.id) AS message_count,
+		model, summary, summarized_count, project_id, memory_enabled, evolving_memory_enabled, belief_memory_enabled
+		FROM chat_sessions WHERE id = ?`
 	args := []any{id}
 	if userID != nil {
 		query += ` AND user_id = ?`
@@ -213,11 +224,11 @@ func (s *sqliteChatStore) ListMessages(ctx context.Context, userID *int64, sessi
 	if _, err := s.GetSession(ctx, userID, sessionID); err != nil {
 		return nil, err
 	}
-	query := `SELECT id, session_id, role, content, created_at FROM chat_messages WHERE session_id = ? ORDER BY created_at ASC, id ASC`
+	query := `SELECT id, session_id, role, content, created_at, duration_ms FROM chat_messages WHERE session_id = ? ORDER BY created_at ASC, id ASC`
 	args := []any{sessionID}
 	if limit > 0 {
-		query = `SELECT id, session_id, role, content, created_at FROM (
-			SELECT id, session_id, role, content, created_at
+		query = `SELECT id, session_id, role, content, created_at, duration_ms FROM (
+			SELECT id, session_id, role, content, created_at, duration_ms
 			FROM chat_messages
 			WHERE session_id = ?
 			ORDER BY created_at DESC, id DESC
@@ -234,10 +245,12 @@ func (s *sqliteChatStore) ListMessages(ctx context.Context, userID *int64, sessi
 	for rows.Next() {
 		var msg persistence.ChatMessage
 		var createdAt sqliteTime
-		if err := rows.Scan(&msg.ID, &msg.SessionID, &msg.Role, &msg.Content, &createdAt); err != nil {
+		var duration sql.NullInt64
+		if err := rows.Scan(&msg.ID, &msg.SessionID, &msg.Role, &msg.Content, &createdAt, &duration); err != nil {
 			return nil, err
 		}
 		msg.CreatedAt = createdAt.Time
+		msg.DurationMs = int64PtrFromNull(duration)
 		out = append(out, msg)
 	}
 	return out, rows.Err()
@@ -339,11 +352,11 @@ func (s *sqliteChatStore) appendMessages(ctx context.Context, req sqliteChatAppe
 		if createdAt.IsZero() {
 			createdAt = time.Now().UTC()
 		}
-		stmt := `INSERT INTO chat_messages(id, session_id, role, content, created_at) VALUES(?, ?, ?, ?, ?)`
+		stmt := `INSERT INTO chat_messages(id, session_id, role, content, created_at, duration_ms) VALUES(?, ?, ?, ?, ?, ?)`
 		if req.SkipExisting {
-			stmt = `INSERT OR IGNORE INTO chat_messages(id, session_id, role, content, created_at) VALUES(?, ?, ?, ?, ?)`
+			stmt = `INSERT OR IGNORE INTO chat_messages(id, session_id, role, content, created_at, duration_ms) VALUES(?, ?, ?, ?, ?, ?)`
 		}
-		if _, err := tx.ExecContext(ctx, stmt, id, req.SessionID, message.Role, message.Content, createdAt); err != nil {
+		if _, err := tx.ExecContext(ctx, stmt, id, req.SessionID, message.Role, message.Content, createdAt, nullableInt64Value(message.DurationMs)); err != nil {
 			return err
 		}
 	}
@@ -357,6 +370,35 @@ WHERE id = ?`, req.Preview, model, model, req.SessionID); err != nil {
 		return err
 	}
 	return tx.Commit()
+}
+
+func ensureSQLiteColumn(ctx context.Context, db *sql.DB, table, column, definition string) error {
+	rows, err := db.QueryContext(ctx, fmt.Sprintf(`PRAGMA table_info(%s)`, table))
+	if err != nil {
+		return err
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var (
+			cid          int
+			name         string
+			columnType   string
+			notNull      int
+			defaultValue any
+			pk           int
+		)
+		if err := rows.Scan(&cid, &name, &columnType, &notNull, &defaultValue, &pk); err != nil {
+			return err
+		}
+		if name == column {
+			return nil
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	_, err = db.ExecContext(ctx, fmt.Sprintf(`ALTER TABLE %s ADD COLUMN %s %s`, table, column, definition))
+	return err
 }
 
 func (s *sqliteChatStore) updateSessionReturning(ctx context.Context, userID *int64, id, assignments string, args ...any) (persistence.ChatSession, error) {
@@ -476,7 +518,7 @@ func scanSQLiteChatSession(row interface {
 	var owner sql.NullInt64
 	var createdAt sqliteTime
 	var updatedAt sqliteTime
-	if err := row.Scan(&session.ID, &session.Name, &session.Kind, &owner, &createdAt, &updatedAt, &session.LastMessagePreview, &session.Model, &session.Summary, &session.SummarizedCount, &session.ProjectID, &session.MemoryEnabled, &session.EvolvingMemoryEnabled, &session.BeliefMemoryEnabled); err != nil {
+	if err := row.Scan(&session.ID, &session.Name, &session.Kind, &owner, &createdAt, &updatedAt, &session.LastMessagePreview, &session.MessageCount, &session.Model, &session.Summary, &session.SummarizedCount, &session.ProjectID, &session.MemoryEnabled, &session.EvolvingMemoryEnabled, &session.BeliefMemoryEnabled); err != nil {
 		return persistence.ChatSession{}, err
 	}
 	session.CreatedAt = createdAt.Time

--- a/internal/persistence/databases/chat_store_sqlite_test.go
+++ b/internal/persistence/databases/chat_store_sqlite_test.go
@@ -21,6 +21,9 @@ func TestSQLiteChatStoreScansTextTimestamps(t *testing.T) {
 	if session.CreatedAt.IsZero() || session.UpdatedAt.IsZero() {
 		t.Fatalf("expected session timestamps, got created=%v updated=%v", session.CreatedAt, session.UpdatedAt)
 	}
+	if session.MessageCount != 0 {
+		t.Fatalf("new session should have 0 messages, got %d", session.MessageCount)
+	}
 
 	sessions, err := store.ListSessions(ctx, nil)
 	if err != nil {
@@ -29,12 +32,16 @@ func TestSQLiteChatStoreScansTextTimestamps(t *testing.T) {
 	if len(sessions) != 1 || sessions[0].ID != "session-sqlite" {
 		t.Fatalf("unexpected sessions: %#v", sessions)
 	}
+	if sessions[0].MessageCount != 0 {
+		t.Fatalf("expected listed message count 0 before append, got %d", sessions[0].MessageCount)
+	}
 
 	now := time.Now().UTC()
+	durationMs := int64(12437)
 	if err := store.AppendMessages(ctx, nil, "session-sqlite", []persistence.ChatMessage{
 		{ID: "m1", Role: "user", Content: "hello", CreatedAt: now},
 		{ID: "m2", Role: "assistant", Content: "working", CreatedAt: now.Add(time.Second)},
-		{ID: "m3", Role: "assistant", Content: "done", CreatedAt: now.Add(2 * time.Second)},
+		{ID: "m3", Role: "assistant", Content: "done", CreatedAt: now.Add(2 * time.Second), DurationMs: &durationMs},
 	}, "done", "test-model"); err != nil {
 		t.Fatalf("AppendMessages: %v", err)
 	}
@@ -46,6 +53,16 @@ func TestSQLiteChatStoreScansTextTimestamps(t *testing.T) {
 	if len(messages) != 3 || messages[0].CreatedAt.IsZero() {
 		t.Fatalf("unexpected messages: %#v", messages)
 	}
+	if messages[2].DurationMs == nil || *messages[2].DurationMs != durationMs {
+		t.Fatalf("expected duration to round trip, got %#v", messages[2].DurationMs)
+	}
+	session, err = store.GetSession(ctx, nil, "session-sqlite")
+	if err != nil {
+		t.Fatalf("GetSession after append: %v", err)
+	}
+	if session.MessageCount != 3 {
+		t.Fatalf("expected message count 3 after append, got %d", session.MessageCount)
+	}
 
 	if err := store.DeleteMessagesAfter(ctx, nil, "session-sqlite", "m2", false); err != nil {
 		t.Fatalf("DeleteMessagesAfter: %v", err)
@@ -56,5 +73,12 @@ func TestSQLiteChatStoreScansTextTimestamps(t *testing.T) {
 	}
 	if len(messages) != 2 || messages[1].ID != "m2" {
 		t.Fatalf("unexpected remaining messages: %#v", messages)
+	}
+	sessions, err = store.ListSessions(ctx, nil)
+	if err != nil {
+		t.Fatalf("ListSessions after delete: %v", err)
+	}
+	if len(sessions) != 1 || sessions[0].MessageCount != 2 {
+		t.Fatalf("expected listed message count 2 after delete, got %#v", sessions)
 	}
 }

--- a/internal/persistence/databases/databases_test.go
+++ b/internal/persistence/databases/databases_test.go
@@ -387,7 +387,7 @@ func TestPostgresMagmaEventDeleteStatementsArePreparedSafe(t *testing.T) {
 }
 
 func TestFactory_DefaultsAndNone(t *testing.T) {
-	t.Parallel()
+	t.Setenv("MANIFOLD_SECRETS_KEY", testSecretsKey(t))
 	ctx := context.Background()
 	// Defaults should create SQLite-backed local backends.
 	mgr, err := NewManager(ctx, config.DBConfig{SQLite: config.SQLiteConfig{Path: t.TempDir() + "/manifold.db"}})
@@ -411,7 +411,7 @@ func TestFactory_DefaultsAndNone(t *testing.T) {
 }
 
 func TestFactory_DefaultSQLitePersistsSpecialistsAcrossManagers(t *testing.T) {
-	t.Parallel()
+	t.Setenv("MANIFOLD_SECRETS_KEY", testSecretsKey(t))
 
 	ctx := context.Background()
 	dbPath := filepath.Join(t.TempDir(), "manifold.db")
@@ -449,7 +449,7 @@ func TestFactory_DefaultSQLitePersistsSpecialistsAcrossManagers(t *testing.T) {
 }
 
 func TestFactory_DefaultSQLitePersistsTeamsAcrossManagers(t *testing.T) {
-	t.Parallel()
+	t.Setenv("MANIFOLD_SECRETS_KEY", testSecretsKey(t))
 
 	ctx := context.Background()
 	dbPath := filepath.Join(t.TempDir(), "manifold.db")
@@ -504,7 +504,7 @@ func TestFactory_DefaultSQLitePersistsTeamsAcrossManagers(t *testing.T) {
 }
 
 func TestSQLiteTeamStoreListDoesNotDeadlockWithSingleConnection(t *testing.T) {
-	t.Parallel()
+	t.Setenv("MANIFOLD_SECRETS_KEY", testSecretsKey(t))
 
 	ctx := context.Background()
 	mgr, err := NewManager(ctx, config.DBConfig{

--- a/internal/persistence/databases/decision_artifact_store_test.go
+++ b/internal/persistence/databases/decision_artifact_store_test.go
@@ -1,0 +1,110 @@
+package databases
+
+import (
+	"context"
+	"testing"
+
+	"manifold/internal/agent/memory/artifact"
+	"manifold/internal/agent/memory/decision"
+)
+
+func TestSQLiteDecisionStoreParity(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	store := NewSQLiteDecisionStore(openTestSQLite(t))
+	if err := store.Init(ctx); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	item, err := store.UpsertDecision(ctx, decision.Decision{
+		TenantID:  7,
+		ScopeID:   "scope",
+		Statement: "Use pgvector for memory search.",
+		Rationale: "It keeps vector retrieval near the existing database.",
+		Status:    decision.DecisionStatusActive,
+	})
+	if err != nil {
+		t.Fatalf("UpsertDecision: %v", err)
+	}
+	if _, err := store.AddAssumption(ctx, decision.AssumptionLink{
+		TenantID:               7,
+		DecisionID:             item.ID,
+		BeliefID:               "belief-1",
+		Criticality:            decision.CriticalityLoadBearing,
+		BeliefStatementAtLink:  "Postgres is available.",
+		BeliefConfidenceAtLink: 0.9,
+	}); err != nil {
+		t.Fatalf("AddAssumption: %v", err)
+	}
+	if _, err := store.AddAlternative(ctx, decision.Alternative{TenantID: 7, DecisionID: item.ID, Statement: "Use Qdrant.", RejectionReason: "Extra service to operate."}); err != nil {
+		t.Fatalf("AddAlternative: %v", err)
+	}
+	if _, err := store.AddEvidence(ctx, decision.DecisionEvidence{TenantID: 7, DecisionID: item.ID, SourceKind: "artifact", SourceID: "artifact-1"}); err != nil {
+		t.Fatalf("AddEvidence: %v", err)
+	}
+	if _, err := store.RecordTransition(ctx, decision.Transition{TenantID: 7, DecisionID: item.ID, ToStatus: decision.DecisionStatusActive}); err != nil {
+		t.Fatalf("RecordTransition: %v", err)
+	}
+	got, ok, err := store.GetDecision(ctx, 7, item.ID)
+	if err != nil || !ok {
+		t.Fatalf("GetDecision ok=%v err=%v", ok, err)
+	}
+	if got.StatementHash == "" || got.Statement != item.Statement {
+		t.Fatalf("unexpected decision: %+v", got)
+	}
+	results, err := store.SearchDecisions(ctx, decision.SearchQuery{TenantID: 7, ScopeIDs: []string{"scope"}, Query: "pgvector", Statuses: []decision.DecisionStatus{decision.DecisionStatusActive}})
+	if err != nil || len(results) != 1 {
+		t.Fatalf("SearchDecisions len=%d err=%v", len(results), err)
+	}
+	if assumptions, _ := store.ListAssumptions(ctx, decision.AssumptionQuery{TenantID: 7, DecisionID: item.ID}); len(assumptions) != 1 {
+		t.Fatalf("expected assumptions")
+	}
+	if alternatives, _ := store.ListAlternatives(ctx, 7, item.ID); len(alternatives) != 1 {
+		t.Fatalf("expected alternatives")
+	}
+	if evidence, _ := store.ListEvidence(ctx, decision.EvidenceQuery{TenantID: 7, DecisionID: item.ID}); len(evidence) != 1 {
+		t.Fatalf("expected evidence")
+	}
+	if transitions, _ := store.ListTransitions(ctx, decision.TransitionQuery{TenantID: 7, DecisionID: item.ID}); len(transitions) != 1 {
+		t.Fatalf("expected transitions")
+	}
+}
+
+func TestSQLiteArtifactStoreParity(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	store := NewSQLiteArtifactStore(openTestSQLite(t))
+	if err := store.Init(ctx); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	first, err := store.UpsertArtifact(ctx, artifact.Artifact{
+		TenantID:   7,
+		Kind:       artifact.ArtifactGitCommit,
+		ExternalID: "abc",
+		Title:      "Adopt pgvector",
+		Excerpt:    "Decision commit",
+	})
+	if err != nil {
+		t.Fatalf("UpsertArtifact first: %v", err)
+	}
+	second, err := store.UpsertArtifact(ctx, artifact.Artifact{
+		TenantID:   7,
+		Kind:       artifact.ArtifactGitCommit,
+		ExternalID: "abc",
+		Title:      "Adopt pgvector",
+		Excerpt:    "Decision commit",
+	})
+	if err != nil {
+		t.Fatalf("UpsertArtifact second: %v", err)
+	}
+	if first.ID != second.ID {
+		t.Fatalf("expected idempotent upsert, first=%+v second=%+v", first, second)
+	}
+	byExternal, err := store.FindByExternalID(ctx, 7, artifact.ArtifactGitCommit, "abc")
+	if err != nil || len(byExternal) != 1 {
+		t.Fatalf("FindByExternalID len=%d err=%v", len(byExternal), err)
+	}
+	results, err := store.SearchArtifacts(ctx, artifact.SearchQuery{TenantID: 7, Query: "pgvector"})
+	if err != nil || len(results) != 1 {
+		t.Fatalf("SearchArtifacts len=%d err=%v", len(results), err)
+	}
+}

--- a/internal/persistence/databases/decision_store_memory.go
+++ b/internal/persistence/databases/decision_store_memory.go
@@ -1,0 +1,433 @@
+package databases
+
+import (
+	"context"
+	"maps"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"manifold/internal/agent/memory/decision"
+
+	"github.com/google/uuid"
+)
+
+// NewMemoryDecisionStore returns an in-memory decision store for local development and tests.
+func NewMemoryDecisionStore() decision.Store {
+	return &memDecisionStore{
+		decisions:    map[string]decision.Decision{},
+		assumptions:  map[string]decision.AssumptionLink{},
+		alternatives: map[string]decision.Alternative{},
+		evidence:     map[string]decision.DecisionEvidence{},
+		transitions:  map[string]decision.Transition{},
+		candidates:   map[string]decision.Candidate{},
+	}
+}
+
+type memDecisionStore struct {
+	mu           sync.RWMutex
+	decisions    map[string]decision.Decision
+	assumptions  map[string]decision.AssumptionLink
+	alternatives map[string]decision.Alternative
+	evidence     map[string]decision.DecisionEvidence
+	transitions  map[string]decision.Transition
+	candidates   map[string]decision.Candidate
+}
+
+func (s *memDecisionStore) Init(context.Context) error { return nil }
+
+func (s *memDecisionStore) UpsertDecision(_ context.Context, item decision.Decision) (decision.Decision, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	item = prepareDecision(item)
+	for id, existing := range s.decisions {
+		if existing.TenantID == item.TenantID && existing.ScopeID == item.ScopeID && existing.StatementHash == item.StatementHash && id != item.ID {
+			item.ID = id
+			item.CreatedAt = existing.CreatedAt
+			break
+		}
+	}
+	s.decisions[item.ID] = cloneDecision(item)
+	return cloneDecision(item), nil
+}
+
+func (s *memDecisionStore) GetDecision(_ context.Context, tenantID int64, id string) (decision.Decision, bool, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	item, ok := s.decisions[strings.TrimSpace(id)]
+	if !ok || item.TenantID != normalizeTenantID(tenantID) {
+		return decision.Decision{}, false, nil
+	}
+	return cloneDecision(item), true, nil
+}
+
+func (s *memDecisionStore) SearchDecisions(_ context.Context, query decision.SearchQuery) ([]decision.SearchResult, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	limit := query.Limit
+	if limit <= 0 {
+		limit = 10
+	}
+	tenantID := normalizeTenantID(query.TenantID)
+	scopeSet := map[string]bool{}
+	for _, scopeID := range query.ScopeIDs {
+		if trimmed := strings.TrimSpace(scopeID); trimmed != "" {
+			scopeSet[trimmed] = true
+		}
+	}
+	statusSet := map[decision.DecisionStatus]bool{}
+	for _, status := range query.Statuses {
+		statusSet[decision.NormalizeDecisionStatus(status)] = true
+	}
+	needle := strings.ToLower(strings.TrimSpace(query.Query))
+	out := make([]decision.SearchResult, 0, limit)
+	for _, item := range s.decisions {
+		if item.TenantID != tenantID {
+			continue
+		}
+		if len(scopeSet) > 0 && !scopeSet[item.ScopeID] {
+			continue
+		}
+		if len(statusSet) > 0 && !statusSet[decision.NormalizeDecisionStatus(item.Status)] {
+			continue
+		}
+		text := strings.ToLower(item.Title + " " + item.Statement + " " + item.Rationale)
+		if needle != "" && !strings.Contains(text, needle) && item.StatementHash != needle {
+			continue
+		}
+		score := item.Confidence
+		if needle != "" {
+			score += 0.1
+		}
+		out = append(out, decision.SearchResult{Decision: cloneDecision(item), Score: score})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Score == out[j].Score {
+			return out[i].Decision.UpdatedAt.After(out[j].Decision.UpdatedAt)
+		}
+		return out[i].Score > out[j].Score
+	})
+	if len(out) > limit {
+		out = out[:limit]
+	}
+	return out, nil
+}
+
+func (s *memDecisionStore) AddAssumption(_ context.Context, link decision.AssumptionLink) (decision.AssumptionLink, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	link.TenantID = normalizeTenantID(link.TenantID)
+	if strings.TrimSpace(link.ID) == "" {
+		link.ID = uuid.NewString()
+	}
+	link.Criticality = decision.NormalizeAssumptionCriticality(link.Criticality)
+	if link.Metadata == nil {
+		link.Metadata = map[string]any{}
+	}
+	if link.CreatedAt.IsZero() {
+		link.CreatedAt = time.Now().UTC()
+	}
+	s.assumptions[link.ID] = cloneAssumption(link)
+	return cloneAssumption(link), nil
+}
+
+func (s *memDecisionStore) ListAssumptions(_ context.Context, query decision.AssumptionQuery) ([]decision.AssumptionLink, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	limit := query.Limit
+	if limit <= 0 {
+		limit = 100
+	}
+	out := make([]decision.AssumptionLink, 0, limit)
+	for _, link := range s.assumptions {
+		if link.TenantID != normalizeTenantID(query.TenantID) {
+			continue
+		}
+		if query.DecisionID != "" && link.DecisionID != strings.TrimSpace(query.DecisionID) {
+			continue
+		}
+		if query.BeliefID != "" && link.BeliefID != strings.TrimSpace(query.BeliefID) {
+			continue
+		}
+		out = append(out, cloneAssumption(link))
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].CreatedAt.Before(out[j].CreatedAt) })
+	if len(out) > limit {
+		out = out[:limit]
+	}
+	return out, nil
+}
+
+func (s *memDecisionStore) AddAlternative(_ context.Context, alt decision.Alternative) (decision.Alternative, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	alt.TenantID = normalizeTenantID(alt.TenantID)
+	if strings.TrimSpace(alt.ID) == "" {
+		alt.ID = uuid.NewString()
+	}
+	alt.Statement = decision.NormalizeStatement(alt.Statement)
+	if alt.Metadata == nil {
+		alt.Metadata = map[string]any{}
+	}
+	if alt.CreatedAt.IsZero() {
+		alt.CreatedAt = time.Now().UTC()
+	}
+	s.alternatives[alt.ID] = cloneAlternative(alt)
+	return cloneAlternative(alt), nil
+}
+
+func (s *memDecisionStore) ListAlternatives(_ context.Context, tenantID int64, decisionID string) ([]decision.Alternative, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := []decision.Alternative{}
+	for _, alt := range s.alternatives {
+		if alt.TenantID != normalizeTenantID(tenantID) || alt.DecisionID != strings.TrimSpace(decisionID) {
+			continue
+		}
+		out = append(out, cloneAlternative(alt))
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].CreatedAt.Before(out[j].CreatedAt) })
+	return out, nil
+}
+
+func (s *memDecisionStore) AddEvidence(_ context.Context, ev decision.DecisionEvidence) (decision.DecisionEvidence, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	ev.TenantID = normalizeTenantID(ev.TenantID)
+	if strings.TrimSpace(ev.ID) == "" {
+		ev.ID = uuid.NewString()
+	}
+	ev.SourceKind = strings.TrimSpace(ev.SourceKind)
+	ev.SourceID = strings.TrimSpace(ev.SourceID)
+	ev.Polarity = decision.NormalizeEvidencePolarity(ev.Polarity)
+	if ev.Weight == 0 {
+		ev.Weight = 1
+	}
+	if ev.Metadata == nil {
+		ev.Metadata = map[string]any{}
+	}
+	if ev.CreatedAt.IsZero() {
+		ev.CreatedAt = time.Now().UTC()
+	}
+	s.evidence[ev.ID] = cloneDecisionEvidence(ev)
+	return cloneDecisionEvidence(ev), nil
+}
+
+func (s *memDecisionStore) ListEvidence(_ context.Context, query decision.EvidenceQuery) ([]decision.DecisionEvidence, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	limit := query.Limit
+	if limit <= 0 {
+		limit = 100
+	}
+	out := make([]decision.DecisionEvidence, 0, limit)
+	for _, ev := range s.evidence {
+		if ev.TenantID != normalizeTenantID(query.TenantID) {
+			continue
+		}
+		if query.DecisionID != "" && ev.DecisionID != strings.TrimSpace(query.DecisionID) {
+			continue
+		}
+		if query.SourceKind != "" && ev.SourceKind != strings.TrimSpace(query.SourceKind) {
+			continue
+		}
+		if query.SourceID != "" && ev.SourceID != strings.TrimSpace(query.SourceID) {
+			continue
+		}
+		if query.Polarity != "" && ev.Polarity != decision.NormalizeEvidencePolarity(query.Polarity) {
+			continue
+		}
+		out = append(out, cloneDecisionEvidence(ev))
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].CreatedAt.Before(out[j].CreatedAt) })
+	if len(out) > limit {
+		out = out[:limit]
+	}
+	return out, nil
+}
+
+func (s *memDecisionStore) RecordTransition(_ context.Context, tr decision.Transition) (decision.Transition, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	tr.TenantID = normalizeTenantID(tr.TenantID)
+	if strings.TrimSpace(tr.ID) == "" {
+		tr.ID = uuid.NewString()
+	}
+	if tr.CreatedAt.IsZero() {
+		tr.CreatedAt = time.Now().UTC()
+	}
+	s.transitions[tr.ID] = cloneTransition(tr)
+	return cloneTransition(tr), nil
+}
+
+func (s *memDecisionStore) ListTransitions(_ context.Context, query decision.TransitionQuery) ([]decision.Transition, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	limit := query.Limit
+	if limit <= 0 {
+		limit = 100
+	}
+	out := make([]decision.Transition, 0, limit)
+	for _, tr := range s.transitions {
+		if tr.TenantID != normalizeTenantID(query.TenantID) {
+			continue
+		}
+		if query.DecisionID != "" && tr.DecisionID != strings.TrimSpace(query.DecisionID) {
+			continue
+		}
+		out = append(out, cloneTransition(tr))
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].CreatedAt.Before(out[j].CreatedAt) })
+	if len(out) > limit {
+		out = out[:limit]
+	}
+	return out, nil
+}
+
+func (s *memDecisionStore) RecordCandidate(_ context.Context, c decision.Candidate) (decision.Candidate, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	c.TenantID = normalizeTenantID(c.TenantID)
+	if strings.TrimSpace(c.ID) == "" {
+		c.ID = uuid.NewString()
+	}
+	c.Statement = decision.NormalizeStatement(c.Statement)
+	if strings.TrimSpace(c.StatementHash) == "" {
+		c.StatementHash = decision.StatementHash(c.Statement)
+	}
+	c.ReviewState = decision.NormalizeReviewState(c.ReviewState)
+	c.ValidationStatus = decision.NormalizeCandidateValidationStatus(c.ValidationStatus)
+	c.Confidence = clampDecisionConfidence(c.Confidence)
+	now := time.Now().UTC()
+	if c.CreatedAt.IsZero() {
+		c.CreatedAt = now
+	}
+	c.UpdatedAt = now
+	if c.Metadata == nil {
+		c.Metadata = map[string]any{}
+	}
+	s.candidates[c.ID] = cloneCandidate(c)
+	return cloneCandidate(c), nil
+}
+
+func (s *memDecisionStore) GetCandidate(_ context.Context, tenantID int64, id string) (decision.Candidate, bool, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	c, ok := s.candidates[strings.TrimSpace(id)]
+	if !ok || c.TenantID != normalizeTenantID(tenantID) {
+		return decision.Candidate{}, false, nil
+	}
+	return cloneCandidate(c), true, nil
+}
+
+func (s *memDecisionStore) ListCandidates(_ context.Context, query decision.CandidateQuery) ([]decision.Candidate, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	limit := query.Limit
+	if limit <= 0 {
+		limit = 100
+	}
+	out := make([]decision.Candidate, 0, limit)
+	for _, c := range s.candidates {
+		if c.TenantID != normalizeTenantID(query.TenantID) {
+			continue
+		}
+		if query.EpisodeID != "" && c.EpisodeID != strings.TrimSpace(query.EpisodeID) {
+			continue
+		}
+		if query.ReviewState != "" && c.ReviewState != decision.NormalizeReviewState(query.ReviewState) {
+			continue
+		}
+		if query.ValidationStatus != "" && c.ValidationStatus != decision.NormalizeCandidateValidationStatus(query.ValidationStatus) {
+			continue
+		}
+		out = append(out, cloneCandidate(c))
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].CreatedAt.Before(out[j].CreatedAt) })
+	if len(out) > limit {
+		out = out[:limit]
+	}
+	return out, nil
+}
+
+func prepareDecision(item decision.Decision) decision.Decision {
+	now := time.Now().UTC()
+	item.TenantID = normalizeTenantID(item.TenantID)
+	if strings.TrimSpace(item.ID) == "" {
+		item.ID = uuid.NewString()
+	}
+	item.Statement = decision.NormalizeStatement(item.Statement)
+	if strings.TrimSpace(item.StatementHash) == "" {
+		item.StatementHash = decision.StatementHash(item.Statement)
+	}
+	item.Status = decision.NormalizeDecisionStatus(item.Status)
+	item.ReviewState = decision.NormalizeReviewState(item.ReviewState)
+	item.Confidence = clampDecisionConfidence(item.Confidence)
+	if item.Title == "" {
+		item.Title = item.Statement
+	}
+	if item.DecidedAt.IsZero() {
+		item.DecidedAt = now
+	}
+	if item.CreatedAt.IsZero() {
+		item.CreatedAt = now
+	}
+	item.UpdatedAt = now
+	if item.Metadata == nil {
+		item.Metadata = map[string]any{}
+	}
+	return item
+}
+
+func cloneDecision(item decision.Decision) decision.Decision {
+	item.Embedding = append([]float32(nil), item.Embedding...)
+	item.Metadata = maps.Clone(item.Metadata)
+	return item
+}
+
+func cloneAssumption(link decision.AssumptionLink) decision.AssumptionLink {
+	link.Metadata = maps.Clone(link.Metadata)
+	return link
+}
+
+func cloneAlternative(alt decision.Alternative) decision.Alternative {
+	alt.Metadata = maps.Clone(alt.Metadata)
+	return alt
+}
+
+func cloneDecisionEvidence(ev decision.DecisionEvidence) decision.DecisionEvidence {
+	ev.Metadata = maps.Clone(ev.Metadata)
+	return ev
+}
+
+func cloneTransition(tr decision.Transition) decision.Transition {
+	if tr.ActorUserID != nil {
+		v := *tr.ActorUserID
+		tr.ActorUserID = &v
+	}
+	return tr
+}
+
+func cloneCandidate(c decision.Candidate) decision.Candidate {
+	c.Alternatives = append([]decision.Alternative(nil), c.Alternatives...)
+	for i := range c.Alternatives {
+		c.Alternatives[i] = cloneAlternative(c.Alternatives[i])
+	}
+	c.AssumptionHints = append([]string(nil), c.AssumptionHints...)
+	c.EvidenceHints = append([]decision.EvidenceHint(nil), c.EvidenceHints...)
+	c.Metadata = maps.Clone(c.Metadata)
+	return c
+}
+
+func clampDecisionConfidence(value float64) float64 {
+	if value < 0 {
+		return 0
+	}
+	if value > 1 {
+		return 1
+	}
+	return value
+}

--- a/internal/persistence/databases/decision_store_postgres.go
+++ b/internal/persistence/databases/decision_store_postgres.go
@@ -1,0 +1,577 @@
+package databases
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sort"
+	"strings"
+	"time"
+
+	"manifold/internal/agent/memory/decision"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// NewPostgresDecisionStoreWithDimensions returns a Postgres-backed decision store.
+func NewPostgresDecisionStoreWithDimensions(pool *pgxpool.Pool, _ int) decision.Store {
+	if pool == nil {
+		return NewMemoryDecisionStore()
+	}
+	return &pgDecisionStore{pool: pool}
+}
+
+type pgDecisionStore struct {
+	pool *pgxpool.Pool
+}
+
+func (s *pgDecisionStore) Close() {
+	if s.pool != nil {
+		s.pool.Close()
+	}
+}
+
+func (s *pgDecisionStore) Init(ctx context.Context) error {
+	if s.pool == nil {
+		return errors.New("postgres decision store requires pool")
+	}
+	if _, err := s.pool.Exec(ctx, `CREATE EXTENSION IF NOT EXISTS vector`); err != nil {
+		return err
+	}
+	_, err := s.pool.Exec(ctx, `
+CREATE TABLE IF NOT EXISTS decision_records (
+	id TEXT PRIMARY KEY,
+	tenant_id BIGINT NOT NULL,
+	scope_id TEXT NOT NULL,
+	episode_id TEXT,
+	title TEXT NOT NULL,
+	statement TEXT NOT NULL,
+	statement_hash TEXT NOT NULL,
+	rationale TEXT NOT NULL DEFAULT '',
+	decided_by TEXT NOT NULL DEFAULT '',
+	decided_at TIMESTAMPTZ NOT NULL,
+	status TEXT NOT NULL,
+	review_state TEXT NOT NULL,
+	confidence DOUBLE PRECISION NOT NULL DEFAULT 0,
+	superseded_by TEXT,
+	stale_reason TEXT,
+	embedding_vec vector,
+	metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+	payload JSONB NOT NULL DEFAULT '{}'::jsonb,
+	search_tsv tsvector GENERATED ALWAYS AS (
+		to_tsvector('simple', coalesce(title, '') || ' ' || coalesce(statement, '') || ' ' || coalesce(rationale, ''))
+	) STORED,
+	created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+	updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE UNIQUE INDEX IF NOT EXISTS decision_records_tenant_scope_hash
+	ON decision_records(tenant_id, scope_id, statement_hash);
+CREATE INDEX IF NOT EXISTS decision_records_tenant_status
+	ON decision_records(tenant_id, status);
+CREATE INDEX IF NOT EXISTS decision_records_search_tsv_idx
+	ON decision_records USING GIN(search_tsv);
+
+CREATE TABLE IF NOT EXISTS decision_assumptions (
+	id TEXT PRIMARY KEY,
+	tenant_id BIGINT NOT NULL,
+	decision_id TEXT NOT NULL REFERENCES decision_records(id),
+	belief_id TEXT NOT NULL,
+	criticality TEXT NOT NULL,
+	belief_statement_at_link TEXT NOT NULL DEFAULT '',
+	belief_confidence_at_link DOUBLE PRECISION NOT NULL DEFAULT 0,
+	note TEXT NOT NULL DEFAULT '',
+	metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+	payload JSONB NOT NULL DEFAULT '{}'::jsonb,
+	created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS decision_assumptions_belief
+	ON decision_assumptions(tenant_id, belief_id);
+CREATE INDEX IF NOT EXISTS decision_assumptions_decision
+	ON decision_assumptions(tenant_id, decision_id);
+
+CREATE TABLE IF NOT EXISTS decision_alternatives (
+	id TEXT PRIMARY KEY,
+	tenant_id BIGINT NOT NULL,
+	decision_id TEXT NOT NULL REFERENCES decision_records(id),
+	statement TEXT NOT NULL,
+	rejection_reason TEXT NOT NULL DEFAULT '',
+	metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+	payload JSONB NOT NULL DEFAULT '{}'::jsonb,
+	created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS decision_alternatives_decision
+	ON decision_alternatives(tenant_id, decision_id);
+
+CREATE TABLE IF NOT EXISTS decision_evidence (
+	id TEXT PRIMARY KEY,
+	tenant_id BIGINT NOT NULL,
+	decision_id TEXT NOT NULL REFERENCES decision_records(id),
+	source_kind TEXT NOT NULL,
+	source_id TEXT NOT NULL,
+	polarity TEXT NOT NULL,
+	weight DOUBLE PRECISION NOT NULL DEFAULT 1,
+	note TEXT NOT NULL DEFAULT '',
+	metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+	payload JSONB NOT NULL DEFAULT '{}'::jsonb,
+	created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS decision_evidence_source
+	ON decision_evidence(tenant_id, source_kind, source_id);
+CREATE INDEX IF NOT EXISTS decision_evidence_decision
+	ON decision_evidence(tenant_id, decision_id);
+
+CREATE TABLE IF NOT EXISTS decision_transitions (
+	id TEXT PRIMARY KEY,
+	tenant_id BIGINT NOT NULL,
+	decision_id TEXT NOT NULL REFERENCES decision_records(id),
+	from_status TEXT NOT NULL,
+	to_status TEXT NOT NULL,
+	reason TEXT NOT NULL DEFAULT '',
+	trigger_kind TEXT NOT NULL DEFAULT '',
+	trigger_id TEXT NOT NULL DEFAULT '',
+	actor_user_id BIGINT,
+	payload JSONB NOT NULL DEFAULT '{}'::jsonb,
+	created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS decision_transitions_decision
+	ON decision_transitions(tenant_id, decision_id, created_at);
+
+CREATE TABLE IF NOT EXISTS decision_candidates (
+	id TEXT PRIMARY KEY,
+	tenant_id BIGINT NOT NULL,
+	episode_id TEXT NOT NULL DEFAULT '',
+	scope_id TEXT NOT NULL DEFAULT '',
+	title TEXT NOT NULL,
+	statement TEXT NOT NULL,
+	statement_hash TEXT NOT NULL,
+	rationale TEXT NOT NULL DEFAULT '',
+	payload JSONB NOT NULL DEFAULT '{}'::jsonb,
+	confidence DOUBLE PRECISION NOT NULL DEFAULT 0,
+	review_state TEXT NOT NULL,
+	validation_status TEXT NOT NULL,
+	rejection_reason TEXT,
+	accepted_decision_id TEXT,
+	model TEXT,
+	raw_payload TEXT,
+	metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+	created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+	updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS decision_candidates_tenant_review_created
+	ON decision_candidates(tenant_id, review_state, created_at DESC);
+CREATE INDEX IF NOT EXISTS decision_candidates_tenant_episode_created
+	ON decision_candidates(tenant_id, episode_id, created_at DESC);
+`)
+	return err
+}
+
+func (s *pgDecisionStore) UpsertDecision(ctx context.Context, item decision.Decision) (decision.Decision, error) {
+	item = prepareDecision(item)
+	if existingID, ok, err := s.findDecisionIDByHash(ctx, item.TenantID, item.ScopeID, item.StatementHash); err != nil {
+		return decision.Decision{}, err
+	} else if ok && existingID != item.ID {
+		item.ID = existingID
+	}
+	payload, err := json.Marshal(item)
+	if err != nil {
+		return decision.Decision{}, err
+	}
+	metadata, err := json.Marshal(item.Metadata)
+	if err != nil {
+		return decision.Decision{}, err
+	}
+	_, err = s.pool.Exec(ctx, `
+INSERT INTO decision_records(id, tenant_id, scope_id, episode_id, title, statement, statement_hash, rationale, decided_by, decided_at, status, review_state, confidence, superseded_by, stale_reason, metadata, payload, created_at, updated_at)
+VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16::jsonb, $17::jsonb, $18, $19)
+ON CONFLICT(id) DO UPDATE SET
+	scope_id=EXCLUDED.scope_id,
+	episode_id=EXCLUDED.episode_id,
+	title=EXCLUDED.title,
+	statement=EXCLUDED.statement,
+	statement_hash=EXCLUDED.statement_hash,
+	rationale=EXCLUDED.rationale,
+	decided_by=EXCLUDED.decided_by,
+	decided_at=EXCLUDED.decided_at,
+	status=EXCLUDED.status,
+	review_state=EXCLUDED.review_state,
+	confidence=EXCLUDED.confidence,
+	superseded_by=EXCLUDED.superseded_by,
+	stale_reason=EXCLUDED.stale_reason,
+	metadata=EXCLUDED.metadata,
+	payload=EXCLUDED.payload,
+	updated_at=EXCLUDED.updated_at
+`, item.ID, item.TenantID, item.ScopeID, item.EpisodeID, item.Title, item.Statement, item.StatementHash, item.Rationale, item.DecidedBy, item.DecidedAt, item.Status, item.ReviewState, item.Confidence, nullableString(item.SupersededBy), nullableString(item.StaleReason), string(metadata), string(payload), item.CreatedAt, item.UpdatedAt)
+	if err != nil {
+		return decision.Decision{}, err
+	}
+	return cloneDecision(item), nil
+}
+
+func (s *pgDecisionStore) GetDecision(ctx context.Context, tenantID int64, id string) (decision.Decision, bool, error) {
+	row := s.pool.QueryRow(ctx, `SELECT payload FROM decision_records WHERE tenant_id = $1 AND id = $2`, normalizeTenantID(tenantID), strings.TrimSpace(id))
+	item, ok, err := scanPGJSONRow[decision.Decision](row)
+	if err != nil || !ok {
+		return decision.Decision{}, ok, err
+	}
+	return cloneDecision(item), true, nil
+}
+
+func (s *pgDecisionStore) SearchDecisions(ctx context.Context, query decision.SearchQuery) ([]decision.SearchResult, error) {
+	limit := query.Limit
+	if limit <= 0 {
+		limit = 10
+	}
+	statuses := make([]string, 0, len(query.Statuses))
+	for _, status := range query.Statuses {
+		statuses = append(statuses, string(decision.NormalizeDecisionStatus(status)))
+	}
+	rows, err := s.pool.Query(ctx, `
+SELECT payload,
+	confidence + CASE WHEN $4 = '' THEN 0 ELSE ts_rank(search_tsv, plainto_tsquery('simple', $4)) END AS score
+FROM decision_records
+WHERE tenant_id = $1
+	AND (cardinality($2::text[]) = 0 OR scope_id = ANY($2::text[]))
+	AND (cardinality($3::text[]) = 0 OR status = ANY($3::text[]))
+	AND ($4 = '' OR search_tsv @@ plainto_tsquery('simple', $4) OR statement ILIKE '%' || $4 || '%' OR title ILIKE '%' || $4 || '%' OR rationale ILIKE '%' || $4 || '%')
+ORDER BY score DESC, updated_at DESC
+LIMIT $5
+`, normalizeTenantID(query.TenantID), query.ScopeIDs, statuses, strings.TrimSpace(query.Query), limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := make([]decision.SearchResult, 0, limit)
+	for rows.Next() {
+		item, score, err := scanPGJSONWithScore[decision.Decision](rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, decision.SearchResult{Decision: cloneDecision(item), Score: score})
+	}
+	return out, rows.Err()
+}
+
+func (s *pgDecisionStore) AddAssumption(ctx context.Context, link decision.AssumptionLink) (decision.AssumptionLink, error) {
+	link.TenantID = normalizeTenantID(link.TenantID)
+	if strings.TrimSpace(link.ID) == "" {
+		link.ID = uuid.NewString()
+	}
+	link.Criticality = decision.NormalizeAssumptionCriticality(link.Criticality)
+	if link.Metadata == nil {
+		link.Metadata = map[string]any{}
+	}
+	if link.CreatedAt.IsZero() {
+		link.CreatedAt = time.Now().UTC()
+	}
+	payload, err := json.Marshal(link)
+	if err != nil {
+		return decision.AssumptionLink{}, err
+	}
+	metadata, err := json.Marshal(link.Metadata)
+	if err != nil {
+		return decision.AssumptionLink{}, err
+	}
+	_, err = s.pool.Exec(ctx, `
+INSERT INTO decision_assumptions(id, tenant_id, decision_id, belief_id, criticality, belief_statement_at_link, belief_confidence_at_link, note, metadata, payload, created_at)
+VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9::jsonb, $10::jsonb, $11)
+ON CONFLICT(id) DO UPDATE SET
+	criticality=EXCLUDED.criticality,
+	belief_statement_at_link=EXCLUDED.belief_statement_at_link,
+	belief_confidence_at_link=EXCLUDED.belief_confidence_at_link,
+	note=EXCLUDED.note,
+	metadata=EXCLUDED.metadata,
+	payload=EXCLUDED.payload
+`, link.ID, link.TenantID, link.DecisionID, link.BeliefID, link.Criticality, link.BeliefStatementAtLink, link.BeliefConfidenceAtLink, link.Note, string(metadata), string(payload), link.CreatedAt)
+	return cloneAssumption(link), err
+}
+
+func (s *pgDecisionStore) ListAssumptions(ctx context.Context, query decision.AssumptionQuery) ([]decision.AssumptionLink, error) {
+	rows, err := s.pool.Query(ctx, `
+SELECT payload FROM decision_assumptions
+WHERE tenant_id = $1
+	AND ($2 = '' OR decision_id = $2)
+	AND ($3 = '' OR belief_id = $3)
+ORDER BY created_at ASC
+LIMIT $4
+`, normalizeTenantID(query.TenantID), strings.TrimSpace(query.DecisionID), strings.TrimSpace(query.BeliefID), normalizedLimit(query.Limit, 100))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return scanPGJSONRows[decision.AssumptionLink](rows)
+}
+
+func (s *pgDecisionStore) AddAlternative(ctx context.Context, alt decision.Alternative) (decision.Alternative, error) {
+	alt.TenantID = normalizeTenantID(alt.TenantID)
+	if strings.TrimSpace(alt.ID) == "" {
+		alt.ID = uuid.NewString()
+	}
+	alt.Statement = decision.NormalizeStatement(alt.Statement)
+	if alt.Metadata == nil {
+		alt.Metadata = map[string]any{}
+	}
+	if alt.CreatedAt.IsZero() {
+		alt.CreatedAt = time.Now().UTC()
+	}
+	payload, err := json.Marshal(alt)
+	if err != nil {
+		return decision.Alternative{}, err
+	}
+	metadata, err := json.Marshal(alt.Metadata)
+	if err != nil {
+		return decision.Alternative{}, err
+	}
+	_, err = s.pool.Exec(ctx, `
+INSERT INTO decision_alternatives(id, tenant_id, decision_id, statement, rejection_reason, metadata, payload, created_at)
+VALUES($1, $2, $3, $4, $5, $6::jsonb, $7::jsonb, $8)
+ON CONFLICT(id) DO UPDATE SET statement=EXCLUDED.statement, rejection_reason=EXCLUDED.rejection_reason, metadata=EXCLUDED.metadata, payload=EXCLUDED.payload
+`, alt.ID, alt.TenantID, alt.DecisionID, alt.Statement, alt.RejectionReason, string(metadata), string(payload), alt.CreatedAt)
+	return cloneAlternative(alt), err
+}
+
+func (s *pgDecisionStore) ListAlternatives(ctx context.Context, tenantID int64, decisionID string) ([]decision.Alternative, error) {
+	rows, err := s.pool.Query(ctx, `
+SELECT payload FROM decision_alternatives
+WHERE tenant_id = $1 AND decision_id = $2
+ORDER BY created_at ASC
+`, normalizeTenantID(tenantID), strings.TrimSpace(decisionID))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return scanPGJSONRows[decision.Alternative](rows)
+}
+
+func (s *pgDecisionStore) AddEvidence(ctx context.Context, ev decision.DecisionEvidence) (decision.DecisionEvidence, error) {
+	ev.TenantID = normalizeTenantID(ev.TenantID)
+	if strings.TrimSpace(ev.ID) == "" {
+		ev.ID = uuid.NewString()
+	}
+	ev.Polarity = decision.NormalizeEvidencePolarity(ev.Polarity)
+	if ev.Weight == 0 {
+		ev.Weight = 1
+	}
+	if ev.Metadata == nil {
+		ev.Metadata = map[string]any{}
+	}
+	if ev.CreatedAt.IsZero() {
+		ev.CreatedAt = time.Now().UTC()
+	}
+	payload, err := json.Marshal(ev)
+	if err != nil {
+		return decision.DecisionEvidence{}, err
+	}
+	metadata, err := json.Marshal(ev.Metadata)
+	if err != nil {
+		return decision.DecisionEvidence{}, err
+	}
+	_, err = s.pool.Exec(ctx, `
+INSERT INTO decision_evidence(id, tenant_id, decision_id, source_kind, source_id, polarity, weight, note, metadata, payload, created_at)
+VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9::jsonb, $10::jsonb, $11)
+ON CONFLICT(id) DO UPDATE SET source_kind=EXCLUDED.source_kind, source_id=EXCLUDED.source_id, polarity=EXCLUDED.polarity, weight=EXCLUDED.weight, note=EXCLUDED.note, metadata=EXCLUDED.metadata, payload=EXCLUDED.payload
+`, ev.ID, ev.TenantID, ev.DecisionID, ev.SourceKind, ev.SourceID, ev.Polarity, ev.Weight, ev.Note, string(metadata), string(payload), ev.CreatedAt)
+	return cloneDecisionEvidence(ev), err
+}
+
+func (s *pgDecisionStore) ListEvidence(ctx context.Context, query decision.EvidenceQuery) ([]decision.DecisionEvidence, error) {
+	rows, err := s.pool.Query(ctx, `
+SELECT payload FROM decision_evidence
+WHERE tenant_id = $1
+	AND ($2 = '' OR decision_id = $2)
+	AND ($3 = '' OR source_kind = $3)
+	AND ($4 = '' OR source_id = $4)
+	AND ($5 = '' OR polarity = $5)
+ORDER BY created_at ASC
+LIMIT $6
+`, normalizeTenantID(query.TenantID), strings.TrimSpace(query.DecisionID), strings.TrimSpace(query.SourceKind), strings.TrimSpace(query.SourceID), string(query.Polarity), normalizedLimit(query.Limit, 100))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return scanPGJSONRows[decision.DecisionEvidence](rows)
+}
+
+func (s *pgDecisionStore) RecordTransition(ctx context.Context, tr decision.Transition) (decision.Transition, error) {
+	tr.TenantID = normalizeTenantID(tr.TenantID)
+	if strings.TrimSpace(tr.ID) == "" {
+		tr.ID = uuid.NewString()
+	}
+	if tr.CreatedAt.IsZero() {
+		tr.CreatedAt = time.Now().UTC()
+	}
+	payload, err := json.Marshal(tr)
+	if err != nil {
+		return decision.Transition{}, err
+	}
+	var actor any
+	if tr.ActorUserID != nil {
+		actor = *tr.ActorUserID
+	}
+	_, err = s.pool.Exec(ctx, `
+INSERT INTO decision_transitions(id, tenant_id, decision_id, from_status, to_status, reason, trigger_kind, trigger_id, actor_user_id, payload, created_at)
+VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, $10::jsonb, $11)
+ON CONFLICT(id) DO UPDATE SET payload=EXCLUDED.payload
+`, tr.ID, tr.TenantID, tr.DecisionID, tr.FromStatus, tr.ToStatus, tr.Reason, tr.TriggerKind, tr.TriggerID, actor, string(payload), tr.CreatedAt)
+	return cloneTransition(tr), err
+}
+
+func (s *pgDecisionStore) ListTransitions(ctx context.Context, query decision.TransitionQuery) ([]decision.Transition, error) {
+	rows, err := s.pool.Query(ctx, `
+SELECT payload FROM decision_transitions
+WHERE tenant_id = $1 AND ($2 = '' OR decision_id = $2)
+ORDER BY created_at ASC
+LIMIT $3
+`, normalizeTenantID(query.TenantID), strings.TrimSpace(query.DecisionID), normalizedLimit(query.Limit, 100))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return scanPGJSONRows[decision.Transition](rows)
+}
+
+func (s *pgDecisionStore) RecordCandidate(ctx context.Context, c decision.Candidate) (decision.Candidate, error) {
+	c.TenantID = normalizeTenantID(c.TenantID)
+	if strings.TrimSpace(c.ID) == "" {
+		c.ID = uuid.NewString()
+	}
+	c.Statement = decision.NormalizeStatement(c.Statement)
+	if strings.TrimSpace(c.StatementHash) == "" {
+		c.StatementHash = decision.StatementHash(c.Statement)
+	}
+	c.ReviewState = decision.NormalizeReviewState(c.ReviewState)
+	c.ValidationStatus = decision.NormalizeCandidateValidationStatus(c.ValidationStatus)
+	c.Confidence = clampDecisionConfidence(c.Confidence)
+	now := time.Now().UTC()
+	if c.CreatedAt.IsZero() {
+		c.CreatedAt = now
+	}
+	c.UpdatedAt = now
+	if c.Metadata == nil {
+		c.Metadata = map[string]any{}
+	}
+	payload, err := json.Marshal(c)
+	if err != nil {
+		return decision.Candidate{}, err
+	}
+	metadata, err := json.Marshal(c.Metadata)
+	if err != nil {
+		return decision.Candidate{}, err
+	}
+	_, err = s.pool.Exec(ctx, `
+INSERT INTO decision_candidates(id, tenant_id, episode_id, scope_id, title, statement, statement_hash, rationale, payload, confidence, review_state, validation_status, rejection_reason, accepted_decision_id, model, raw_payload, metadata, created_at, updated_at)
+VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9::jsonb, $10, $11, $12, $13, $14, $15, $16, $17::jsonb, $18, $19)
+ON CONFLICT(id) DO UPDATE SET
+	title=EXCLUDED.title,
+	statement=EXCLUDED.statement,
+	statement_hash=EXCLUDED.statement_hash,
+	rationale=EXCLUDED.rationale,
+	payload=EXCLUDED.payload,
+	confidence=EXCLUDED.confidence,
+	review_state=EXCLUDED.review_state,
+	validation_status=EXCLUDED.validation_status,
+	rejection_reason=EXCLUDED.rejection_reason,
+	accepted_decision_id=EXCLUDED.accepted_decision_id,
+	model=EXCLUDED.model,
+	raw_payload=EXCLUDED.raw_payload,
+	metadata=EXCLUDED.metadata,
+	updated_at=EXCLUDED.updated_at
+`, c.ID, c.TenantID, c.EpisodeID, c.ScopeID, c.Title, c.Statement, c.StatementHash, c.Rationale, string(payload), c.Confidence, c.ReviewState, c.ValidationStatus, nullableString(c.RejectionReason), nullableString(c.AcceptedDecisionID), nullableString(c.Model), nullableString(c.RawPayload), string(metadata), c.CreatedAt, c.UpdatedAt)
+	return cloneCandidate(c), err
+}
+
+func (s *pgDecisionStore) GetCandidate(ctx context.Context, tenantID int64, id string) (decision.Candidate, bool, error) {
+	row := s.pool.QueryRow(ctx, `SELECT payload FROM decision_candidates WHERE tenant_id = $1 AND id = $2`, normalizeTenantID(tenantID), strings.TrimSpace(id))
+	item, ok, err := scanPGJSONRow[decision.Candidate](row)
+	if err != nil || !ok {
+		return decision.Candidate{}, ok, err
+	}
+	return cloneCandidate(item), true, nil
+}
+
+func (s *pgDecisionStore) ListCandidates(ctx context.Context, query decision.CandidateQuery) ([]decision.Candidate, error) {
+	rows, err := s.pool.Query(ctx, `
+SELECT payload FROM decision_candidates
+WHERE tenant_id = $1
+	AND ($2 = '' OR episode_id = $2)
+	AND ($3 = '' OR review_state = $3)
+	AND ($4 = '' OR validation_status = $4)
+ORDER BY created_at ASC
+LIMIT $5
+`, normalizeTenantID(query.TenantID), strings.TrimSpace(query.EpisodeID), string(query.ReviewState), string(query.ValidationStatus), normalizedLimit(query.Limit, 100))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return scanPGJSONRows[decision.Candidate](rows)
+}
+
+func (s *pgDecisionStore) findDecisionIDByHash(ctx context.Context, tenantID int64, scopeID, hash string) (string, bool, error) {
+	var id string
+	err := s.pool.QueryRow(ctx, `SELECT id FROM decision_records WHERE tenant_id = $1 AND scope_id = $2 AND statement_hash = $3`, normalizeTenantID(tenantID), strings.TrimSpace(scopeID), strings.TrimSpace(hash)).Scan(&id)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return "", false, nil
+	}
+	return id, err == nil, err
+}
+
+func scanPGJSONRow[T any](row pgx.Row) (T, bool, error) {
+	var zero T
+	var payload []byte
+	if err := row.Scan(&payload); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return zero, false, nil
+		}
+		return zero, false, err
+	}
+	var out T
+	if err := json.Unmarshal(payload, &out); err != nil {
+		return zero, false, err
+	}
+	return out, true, nil
+}
+
+func scanPGJSONWithScore[T any](rows pgx.Rows) (T, float64, error) {
+	var zero T
+	var payload []byte
+	var score float64
+	if err := rows.Scan(&payload, &score); err != nil {
+		return zero, 0, err
+	}
+	var out T
+	if err := json.Unmarshal(payload, &out); err != nil {
+		return zero, 0, err
+	}
+	return out, score, nil
+}
+
+func scanPGJSONRows[T any](rows pgx.Rows) ([]T, error) {
+	out := []T{}
+	for rows.Next() {
+		item, ok, err := scanPGJSONRow[T](rows)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
+			out = append(out, item)
+		}
+	}
+	return out, rows.Err()
+}
+
+func normalizedLimit(limit, fallback int) int {
+	if limit <= 0 {
+		return fallback
+	}
+	return limit
+}
+
+func sortDecisionResults(out []decision.SearchResult) {
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Score == out[j].Score {
+			return out[i].Decision.UpdatedAt.After(out[j].Decision.UpdatedAt)
+		}
+		return out[i].Score > out[j].Score
+	})
+}

--- a/internal/persistence/databases/decision_store_sqlite.go
+++ b/internal/persistence/databases/decision_store_sqlite.go
@@ -1,0 +1,560 @@
+package databases
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"sort"
+	"strings"
+	"time"
+
+	"manifold/internal/agent/memory/decision"
+
+	"github.com/google/uuid"
+)
+
+type sqliteDecisionStore struct {
+	db *sql.DB
+}
+
+// NewSQLiteDecisionStore returns a SQLite-backed decision store.
+func NewSQLiteDecisionStore(db *sql.DB) decision.Store {
+	if db == nil {
+		return NewMemoryDecisionStore()
+	}
+	return &sqliteDecisionStore{db: db}
+}
+
+func (s *sqliteDecisionStore) Init(ctx context.Context) error {
+	if s.db == nil {
+		return errors.New("sqlite decision store requires db")
+	}
+	_, err := s.db.ExecContext(ctx, `
+CREATE TABLE IF NOT EXISTS decision_records (
+	id TEXT PRIMARY KEY,
+	tenant_id INTEGER NOT NULL,
+	scope_id TEXT NOT NULL,
+	episode_id TEXT,
+	title TEXT NOT NULL,
+	statement TEXT NOT NULL,
+	statement_hash TEXT NOT NULL,
+	rationale TEXT NOT NULL DEFAULT '',
+	decided_by TEXT NOT NULL DEFAULT '',
+	decided_at DATETIME NOT NULL,
+	status TEXT NOT NULL,
+	review_state TEXT NOT NULL,
+	confidence REAL NOT NULL DEFAULT 0,
+	superseded_by TEXT,
+	stale_reason TEXT,
+	embedding BLOB,
+	metadata TEXT,
+	payload TEXT NOT NULL CHECK(json_valid(payload)),
+	created_at DATETIME NOT NULL,
+	updated_at DATETIME NOT NULL
+);
+CREATE UNIQUE INDEX IF NOT EXISTS decision_records_tenant_scope_hash
+	ON decision_records(tenant_id, scope_id, statement_hash);
+CREATE INDEX IF NOT EXISTS decision_records_tenant_status
+	ON decision_records(tenant_id, status);
+
+CREATE TABLE IF NOT EXISTS decision_assumptions (
+	id TEXT PRIMARY KEY,
+	tenant_id INTEGER NOT NULL,
+	decision_id TEXT NOT NULL,
+	belief_id TEXT NOT NULL,
+	criticality TEXT NOT NULL,
+	belief_statement_at_link TEXT NOT NULL DEFAULT '',
+	belief_confidence_at_link REAL NOT NULL DEFAULT 0,
+	note TEXT NOT NULL DEFAULT '',
+	metadata TEXT,
+	payload TEXT NOT NULL CHECK(json_valid(payload)),
+	created_at DATETIME NOT NULL
+);
+CREATE INDEX IF NOT EXISTS decision_assumptions_belief
+	ON decision_assumptions(tenant_id, belief_id);
+CREATE INDEX IF NOT EXISTS decision_assumptions_decision
+	ON decision_assumptions(tenant_id, decision_id);
+
+CREATE TABLE IF NOT EXISTS decision_alternatives (
+	id TEXT PRIMARY KEY,
+	tenant_id INTEGER NOT NULL,
+	decision_id TEXT NOT NULL,
+	statement TEXT NOT NULL,
+	rejection_reason TEXT NOT NULL DEFAULT '',
+	metadata TEXT,
+	payload TEXT NOT NULL CHECK(json_valid(payload)),
+	created_at DATETIME NOT NULL
+);
+CREATE INDEX IF NOT EXISTS decision_alternatives_decision
+	ON decision_alternatives(tenant_id, decision_id);
+
+CREATE TABLE IF NOT EXISTS decision_evidence (
+	id TEXT PRIMARY KEY,
+	tenant_id INTEGER NOT NULL,
+	decision_id TEXT NOT NULL,
+	source_kind TEXT NOT NULL,
+	source_id TEXT NOT NULL,
+	polarity TEXT NOT NULL,
+	weight REAL NOT NULL DEFAULT 1,
+	note TEXT NOT NULL DEFAULT '',
+	metadata TEXT,
+	payload TEXT NOT NULL CHECK(json_valid(payload)),
+	created_at DATETIME NOT NULL
+);
+CREATE INDEX IF NOT EXISTS decision_evidence_source
+	ON decision_evidence(tenant_id, source_kind, source_id);
+CREATE INDEX IF NOT EXISTS decision_evidence_decision
+	ON decision_evidence(tenant_id, decision_id);
+
+CREATE TABLE IF NOT EXISTS decision_transitions (
+	id TEXT PRIMARY KEY,
+	tenant_id INTEGER NOT NULL,
+	decision_id TEXT NOT NULL,
+	from_status TEXT NOT NULL,
+	to_status TEXT NOT NULL,
+	reason TEXT NOT NULL DEFAULT '',
+	trigger_kind TEXT NOT NULL DEFAULT '',
+	trigger_id TEXT NOT NULL DEFAULT '',
+	actor_user_id INTEGER,
+	payload TEXT NOT NULL CHECK(json_valid(payload)),
+	created_at DATETIME NOT NULL
+);
+CREATE INDEX IF NOT EXISTS decision_transitions_decision
+	ON decision_transitions(tenant_id, decision_id, created_at);
+
+CREATE TABLE IF NOT EXISTS decision_candidates (
+	id TEXT PRIMARY KEY,
+	tenant_id INTEGER NOT NULL,
+	episode_id TEXT NOT NULL DEFAULT '',
+	scope_id TEXT NOT NULL DEFAULT '',
+	title TEXT NOT NULL,
+	statement TEXT NOT NULL,
+	statement_hash TEXT NOT NULL,
+	rationale TEXT NOT NULL DEFAULT '',
+	payload TEXT NOT NULL CHECK(json_valid(payload)),
+	confidence REAL NOT NULL DEFAULT 0,
+	review_state TEXT NOT NULL,
+	validation_status TEXT NOT NULL,
+	rejection_reason TEXT,
+	accepted_decision_id TEXT,
+	model TEXT,
+	raw_payload TEXT,
+	metadata TEXT,
+	created_at DATETIME NOT NULL,
+	updated_at DATETIME NOT NULL
+);
+`)
+	return err
+}
+
+func (s *sqliteDecisionStore) UpsertDecision(ctx context.Context, item decision.Decision) (decision.Decision, error) {
+	if err := s.Init(ctx); err != nil {
+		return decision.Decision{}, err
+	}
+	item = prepareDecision(item)
+	if existingID, ok, err := s.findDecisionIDByHash(ctx, item.TenantID, item.ScopeID, item.StatementHash); err != nil {
+		return decision.Decision{}, err
+	} else if ok && existingID != item.ID {
+		item.ID = existingID
+	}
+	payload, err := json.Marshal(item)
+	if err != nil {
+		return decision.Decision{}, err
+	}
+	metadata, _ := json.Marshal(item.Metadata)
+	_, err = s.db.ExecContext(ctx, `
+INSERT INTO decision_records(id, tenant_id, scope_id, episode_id, title, statement, statement_hash, rationale, decided_by, decided_at, status, review_state, confidence, superseded_by, stale_reason, metadata, payload, created_at, updated_at)
+VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT(id) DO UPDATE SET
+	scope_id=excluded.scope_id,
+	episode_id=excluded.episode_id,
+	title=excluded.title,
+	statement=excluded.statement,
+	statement_hash=excluded.statement_hash,
+	rationale=excluded.rationale,
+	decided_by=excluded.decided_by,
+	decided_at=excluded.decided_at,
+	status=excluded.status,
+	review_state=excluded.review_state,
+	confidence=excluded.confidence,
+	superseded_by=excluded.superseded_by,
+	stale_reason=excluded.stale_reason,
+	metadata=excluded.metadata,
+	payload=excluded.payload,
+	updated_at=excluded.updated_at
+`, item.ID, item.TenantID, item.ScopeID, item.EpisodeID, item.Title, item.Statement, item.StatementHash, item.Rationale, item.DecidedBy, sqliteTime{Time: item.DecidedAt}, item.Status, item.ReviewState, item.Confidence, nullableString(item.SupersededBy), nullableString(item.StaleReason), string(metadata), string(payload), sqliteTime{Time: item.CreatedAt}, sqliteTime{Time: item.UpdatedAt})
+	if err != nil {
+		return decision.Decision{}, err
+	}
+	return cloneDecision(item), nil
+}
+
+func (s *sqliteDecisionStore) GetDecision(ctx context.Context, tenantID int64, id string) (decision.Decision, bool, error) {
+	if err := s.Init(ctx); err != nil {
+		return decision.Decision{}, false, err
+	}
+	row := s.db.QueryRowContext(ctx, `SELECT payload FROM decision_records WHERE tenant_id = ? AND id = ?`, normalizeTenantID(tenantID), strings.TrimSpace(id))
+	item, ok, err := scanJSONRow[decision.Decision](row)
+	if err != nil || !ok {
+		return decision.Decision{}, ok, err
+	}
+	return cloneDecision(item), true, nil
+}
+
+func (s *sqliteDecisionStore) SearchDecisions(ctx context.Context, query decision.SearchQuery) ([]decision.SearchResult, error) {
+	if err := s.Init(ctx); err != nil {
+		return nil, err
+	}
+	rows, err := s.db.QueryContext(ctx, `SELECT payload FROM decision_records WHERE tenant_id = ?`, normalizeTenantID(query.TenantID))
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	scopeSet := stringSet(query.ScopeIDs)
+	statusSet := map[decision.DecisionStatus]bool{}
+	for _, status := range query.Statuses {
+		statusSet[decision.NormalizeDecisionStatus(status)] = true
+	}
+	needle := strings.ToLower(strings.TrimSpace(query.Query))
+	limit := query.Limit
+	if limit <= 0 {
+		limit = 10
+	}
+	out := []decision.SearchResult{}
+	for rows.Next() {
+		item, err := scanJSONRows[decision.Decision](rows)
+		if err != nil {
+			return nil, err
+		}
+		if len(scopeSet) > 0 && !scopeSet[item.ScopeID] {
+			continue
+		}
+		if len(statusSet) > 0 && !statusSet[decision.NormalizeDecisionStatus(item.Status)] {
+			continue
+		}
+		text := strings.ToLower(item.Title + " " + item.Statement + " " + item.Rationale)
+		if needle != "" && !strings.Contains(text, needle) && item.StatementHash != needle {
+			continue
+		}
+		score := item.Confidence
+		if needle != "" {
+			score += 0.1
+		}
+		out = append(out, decision.SearchResult{Decision: cloneDecision(item), Score: score})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Score == out[j].Score {
+			return out[i].Decision.UpdatedAt.After(out[j].Decision.UpdatedAt)
+		}
+		return out[i].Score > out[j].Score
+	})
+	if len(out) > limit {
+		out = out[:limit]
+	}
+	return out, nil
+}
+
+func (s *sqliteDecisionStore) AddAssumption(ctx context.Context, link decision.AssumptionLink) (decision.AssumptionLink, error) {
+	if err := s.Init(ctx); err != nil {
+		return decision.AssumptionLink{}, err
+	}
+	link.TenantID = normalizeTenantID(link.TenantID)
+	if strings.TrimSpace(link.ID) == "" {
+		link.ID = uuid.NewString()
+	}
+	link.Criticality = decision.NormalizeAssumptionCriticality(link.Criticality)
+	if link.Metadata == nil {
+		link.Metadata = map[string]any{}
+	}
+	if link.CreatedAt.IsZero() {
+		link.CreatedAt = time.Now().UTC()
+	}
+	payload, err := json.Marshal(link)
+	if err != nil {
+		return decision.AssumptionLink{}, err
+	}
+	metadata, _ := json.Marshal(link.Metadata)
+	_, err = s.db.ExecContext(ctx, `
+INSERT INTO decision_assumptions(id, tenant_id, decision_id, belief_id, criticality, belief_statement_at_link, belief_confidence_at_link, note, metadata, payload, created_at)
+VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT(id) DO UPDATE SET criticality=excluded.criticality, belief_statement_at_link=excluded.belief_statement_at_link, belief_confidence_at_link=excluded.belief_confidence_at_link, note=excluded.note, metadata=excluded.metadata, payload=excluded.payload
+`, link.ID, link.TenantID, link.DecisionID, link.BeliefID, link.Criticality, link.BeliefStatementAtLink, link.BeliefConfidenceAtLink, link.Note, string(metadata), string(payload), sqliteTime{Time: link.CreatedAt})
+	return cloneAssumption(link), err
+}
+
+func (s *sqliteDecisionStore) ListAssumptions(ctx context.Context, query decision.AssumptionQuery) ([]decision.AssumptionLink, error) {
+	return listDecisionJSON[decision.AssumptionLink](ctx, s.db, s.Init, `SELECT payload FROM decision_assumptions WHERE tenant_id = ? ORDER BY created_at ASC`, normalizeTenantID(query.TenantID), query.Limit, func(link decision.AssumptionLink) bool {
+		return (query.DecisionID == "" || link.DecisionID == strings.TrimSpace(query.DecisionID)) &&
+			(query.BeliefID == "" || link.BeliefID == strings.TrimSpace(query.BeliefID))
+	})
+}
+
+func (s *sqliteDecisionStore) AddAlternative(ctx context.Context, alt decision.Alternative) (decision.Alternative, error) {
+	if err := s.Init(ctx); err != nil {
+		return decision.Alternative{}, err
+	}
+	alt.TenantID = normalizeTenantID(alt.TenantID)
+	if strings.TrimSpace(alt.ID) == "" {
+		alt.ID = uuid.NewString()
+	}
+	alt.Statement = decision.NormalizeStatement(alt.Statement)
+	if alt.Metadata == nil {
+		alt.Metadata = map[string]any{}
+	}
+	if alt.CreatedAt.IsZero() {
+		alt.CreatedAt = time.Now().UTC()
+	}
+	payload, err := json.Marshal(alt)
+	if err != nil {
+		return decision.Alternative{}, err
+	}
+	metadata, _ := json.Marshal(alt.Metadata)
+	_, err = s.db.ExecContext(ctx, `
+INSERT INTO decision_alternatives(id, tenant_id, decision_id, statement, rejection_reason, metadata, payload, created_at)
+VALUES(?, ?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT(id) DO UPDATE SET statement=excluded.statement, rejection_reason=excluded.rejection_reason, metadata=excluded.metadata, payload=excluded.payload
+`, alt.ID, alt.TenantID, alt.DecisionID, alt.Statement, alt.RejectionReason, string(metadata), string(payload), sqliteTime{Time: alt.CreatedAt})
+	return cloneAlternative(alt), err
+}
+
+func (s *sqliteDecisionStore) ListAlternatives(ctx context.Context, tenantID int64, decisionID string) ([]decision.Alternative, error) {
+	return listDecisionJSON[decision.Alternative](ctx, s.db, s.Init, `SELECT payload FROM decision_alternatives WHERE tenant_id = ? ORDER BY created_at ASC`, normalizeTenantID(tenantID), 0, func(alt decision.Alternative) bool {
+		return alt.DecisionID == strings.TrimSpace(decisionID)
+	})
+}
+
+func (s *sqliteDecisionStore) AddEvidence(ctx context.Context, ev decision.DecisionEvidence) (decision.DecisionEvidence, error) {
+	if err := s.Init(ctx); err != nil {
+		return decision.DecisionEvidence{}, err
+	}
+	ev.TenantID = normalizeTenantID(ev.TenantID)
+	if strings.TrimSpace(ev.ID) == "" {
+		ev.ID = uuid.NewString()
+	}
+	ev.Polarity = decision.NormalizeEvidencePolarity(ev.Polarity)
+	if ev.Weight == 0 {
+		ev.Weight = 1
+	}
+	if ev.Metadata == nil {
+		ev.Metadata = map[string]any{}
+	}
+	if ev.CreatedAt.IsZero() {
+		ev.CreatedAt = time.Now().UTC()
+	}
+	payload, err := json.Marshal(ev)
+	if err != nil {
+		return decision.DecisionEvidence{}, err
+	}
+	metadata, _ := json.Marshal(ev.Metadata)
+	_, err = s.db.ExecContext(ctx, `
+INSERT INTO decision_evidence(id, tenant_id, decision_id, source_kind, source_id, polarity, weight, note, metadata, payload, created_at)
+VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT(id) DO UPDATE SET source_kind=excluded.source_kind, source_id=excluded.source_id, polarity=excluded.polarity, weight=excluded.weight, note=excluded.note, metadata=excluded.metadata, payload=excluded.payload
+`, ev.ID, ev.TenantID, ev.DecisionID, ev.SourceKind, ev.SourceID, ev.Polarity, ev.Weight, ev.Note, string(metadata), string(payload), sqliteTime{Time: ev.CreatedAt})
+	return cloneDecisionEvidence(ev), err
+}
+
+func (s *sqliteDecisionStore) ListEvidence(ctx context.Context, query decision.EvidenceQuery) ([]decision.DecisionEvidence, error) {
+	return listDecisionJSON[decision.DecisionEvidence](ctx, s.db, s.Init, `SELECT payload FROM decision_evidence WHERE tenant_id = ? ORDER BY created_at ASC`, normalizeTenantID(query.TenantID), query.Limit, func(ev decision.DecisionEvidence) bool {
+		return (query.DecisionID == "" || ev.DecisionID == strings.TrimSpace(query.DecisionID)) &&
+			(query.SourceKind == "" || ev.SourceKind == strings.TrimSpace(query.SourceKind)) &&
+			(query.SourceID == "" || ev.SourceID == strings.TrimSpace(query.SourceID)) &&
+			(query.Polarity == "" || ev.Polarity == decision.NormalizeEvidencePolarity(query.Polarity))
+	})
+}
+
+func (s *sqliteDecisionStore) RecordTransition(ctx context.Context, tr decision.Transition) (decision.Transition, error) {
+	if err := s.Init(ctx); err != nil {
+		return decision.Transition{}, err
+	}
+	tr.TenantID = normalizeTenantID(tr.TenantID)
+	if strings.TrimSpace(tr.ID) == "" {
+		tr.ID = uuid.NewString()
+	}
+	if tr.CreatedAt.IsZero() {
+		tr.CreatedAt = time.Now().UTC()
+	}
+	payload, err := json.Marshal(tr)
+	if err != nil {
+		return decision.Transition{}, err
+	}
+	var actor any
+	if tr.ActorUserID != nil {
+		actor = *tr.ActorUserID
+	}
+	_, err = s.db.ExecContext(ctx, `
+INSERT INTO decision_transitions(id, tenant_id, decision_id, from_status, to_status, reason, trigger_kind, trigger_id, actor_user_id, payload, created_at)
+VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT(id) DO UPDATE SET payload=excluded.payload
+`, tr.ID, tr.TenantID, tr.DecisionID, tr.FromStatus, tr.ToStatus, tr.Reason, tr.TriggerKind, tr.TriggerID, actor, string(payload), sqliteTime{Time: tr.CreatedAt})
+	return cloneTransition(tr), err
+}
+
+func (s *sqliteDecisionStore) ListTransitions(ctx context.Context, query decision.TransitionQuery) ([]decision.Transition, error) {
+	return listDecisionJSON[decision.Transition](ctx, s.db, s.Init, `SELECT payload FROM decision_transitions WHERE tenant_id = ? ORDER BY created_at ASC`, normalizeTenantID(query.TenantID), query.Limit, func(tr decision.Transition) bool {
+		return query.DecisionID == "" || tr.DecisionID == strings.TrimSpace(query.DecisionID)
+	})
+}
+
+func (s *sqliteDecisionStore) RecordCandidate(ctx context.Context, c decision.Candidate) (decision.Candidate, error) {
+	if err := s.Init(ctx); err != nil {
+		return decision.Candidate{}, err
+	}
+	c.TenantID = normalizeTenantID(c.TenantID)
+	if strings.TrimSpace(c.ID) == "" {
+		c.ID = uuid.NewString()
+	}
+	c.Statement = decision.NormalizeStatement(c.Statement)
+	if strings.TrimSpace(c.StatementHash) == "" {
+		c.StatementHash = decision.StatementHash(c.Statement)
+	}
+	c.ReviewState = decision.NormalizeReviewState(c.ReviewState)
+	c.ValidationStatus = decision.NormalizeCandidateValidationStatus(c.ValidationStatus)
+	c.Confidence = clampDecisionConfidence(c.Confidence)
+	now := time.Now().UTC()
+	if c.CreatedAt.IsZero() {
+		c.CreatedAt = now
+	}
+	c.UpdatedAt = now
+	if c.Metadata == nil {
+		c.Metadata = map[string]any{}
+	}
+	payload, err := json.Marshal(c)
+	if err != nil {
+		return decision.Candidate{}, err
+	}
+	metadata, _ := json.Marshal(c.Metadata)
+	_, err = s.db.ExecContext(ctx, `
+INSERT INTO decision_candidates(id, tenant_id, episode_id, scope_id, title, statement, statement_hash, rationale, payload, confidence, review_state, validation_status, rejection_reason, accepted_decision_id, model, raw_payload, metadata, created_at, updated_at)
+VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT(id) DO UPDATE SET
+	title=excluded.title,
+	statement=excluded.statement,
+	statement_hash=excluded.statement_hash,
+	rationale=excluded.rationale,
+	payload=excluded.payload,
+	confidence=excluded.confidence,
+	review_state=excluded.review_state,
+	validation_status=excluded.validation_status,
+	rejection_reason=excluded.rejection_reason,
+	accepted_decision_id=excluded.accepted_decision_id,
+	model=excluded.model,
+	raw_payload=excluded.raw_payload,
+	metadata=excluded.metadata,
+	updated_at=excluded.updated_at
+`, c.ID, c.TenantID, c.EpisodeID, c.ScopeID, c.Title, c.Statement, c.StatementHash, c.Rationale, string(payload), c.Confidence, c.ReviewState, c.ValidationStatus, nullableString(c.RejectionReason), nullableString(c.AcceptedDecisionID), nullableString(c.Model), nullableString(c.RawPayload), string(metadata), sqliteTime{Time: c.CreatedAt}, sqliteTime{Time: c.UpdatedAt})
+	return cloneCandidate(c), err
+}
+
+func (s *sqliteDecisionStore) GetCandidate(ctx context.Context, tenantID int64, id string) (decision.Candidate, bool, error) {
+	if err := s.Init(ctx); err != nil {
+		return decision.Candidate{}, false, err
+	}
+	row := s.db.QueryRowContext(ctx, `SELECT payload FROM decision_candidates WHERE tenant_id = ? AND id = ?`, normalizeTenantID(tenantID), strings.TrimSpace(id))
+	c, ok, err := scanJSONRow[decision.Candidate](row)
+	if err != nil || !ok {
+		return decision.Candidate{}, ok, err
+	}
+	return cloneCandidate(c), true, nil
+}
+
+func (s *sqliteDecisionStore) ListCandidates(ctx context.Context, query decision.CandidateQuery) ([]decision.Candidate, error) {
+	return listDecisionJSON[decision.Candidate](ctx, s.db, s.Init, `SELECT payload FROM decision_candidates WHERE tenant_id = ? ORDER BY created_at ASC`, normalizeTenantID(query.TenantID), query.Limit, func(c decision.Candidate) bool {
+		return (query.EpisodeID == "" || c.EpisodeID == strings.TrimSpace(query.EpisodeID)) &&
+			(query.ReviewState == "" || c.ReviewState == decision.NormalizeReviewState(query.ReviewState)) &&
+			(query.ValidationStatus == "" || c.ValidationStatus == decision.NormalizeCandidateValidationStatus(query.ValidationStatus))
+	})
+}
+
+func (s *sqliteDecisionStore) findDecisionIDByHash(ctx context.Context, tenantID int64, scopeID, hash string) (string, bool, error) {
+	var id string
+	err := s.db.QueryRowContext(ctx, `SELECT id FROM decision_records WHERE tenant_id = ? AND scope_id = ? AND statement_hash = ?`, normalizeTenantID(tenantID), strings.TrimSpace(scopeID), strings.TrimSpace(hash)).Scan(&id)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", false, nil
+	}
+	return id, err == nil, err
+}
+
+type payloadScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanJSONRow[T any](row payloadScanner) (T, bool, error) {
+	var zero T
+	var payload string
+	if err := row.Scan(&payload); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return zero, false, nil
+		}
+		return zero, false, err
+	}
+	var out T
+	if err := json.Unmarshal([]byte(payload), &out); err != nil {
+		return zero, false, err
+	}
+	return out, true, nil
+}
+
+func scanJSONRows[T any](rows *sql.Rows) (T, error) {
+	var zero T
+	var payload string
+	if err := rows.Scan(&payload); err != nil {
+		return zero, err
+	}
+	var out T
+	if err := json.Unmarshal([]byte(payload), &out); err != nil {
+		return zero, err
+	}
+	return out, nil
+}
+
+func listDecisionJSON[T any](ctx context.Context, db *sql.DB, init func(context.Context) error, query string, tenantID int64, limit int, keep func(T) bool) ([]T, error) {
+	if err := init(ctx); err != nil {
+		return nil, err
+	}
+	rows, err := db.QueryContext(ctx, query, tenantID)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	if limit <= 0 {
+		limit = 100
+	}
+	out := make([]T, 0, limit)
+	for rows.Next() {
+		item, err := scanJSONRows[T](rows)
+		if err != nil {
+			return nil, err
+		}
+		if keep != nil && !keep(item) {
+			continue
+		}
+		out = append(out, item)
+		if len(out) >= limit {
+			break
+		}
+	}
+	return out, rows.Err()
+}
+
+func nullableString(value string) any {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil
+	}
+	return value
+}
+
+func stringSet(values []string) map[string]bool {
+	out := map[string]bool{}
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			out[trimmed] = true
+		}
+	}
+	return out
+}

--- a/internal/persistence/databases/evolving_memory_archive_test.go
+++ b/internal/persistence/databases/evolving_memory_archive_test.go
@@ -1,0 +1,40 @@
+package databases
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"manifold/internal/agent/memory"
+)
+
+func TestSQLiteEvolvingMemoryArchive(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	store := NewSQLiteEvolvingMemoryStore(openTestSQLite(t))
+	archive, ok := store.(memory.EvolvingMemoryArchiveStore)
+	if !ok {
+		t.Fatalf("sqlite evolving store does not implement archive store")
+	}
+	entry := &memory.MemoryEntry{
+		ID:        "11111111-1111-1111-1111-111111111111",
+		Input:     "why postgres?",
+		Output:    "jsonb preserves payloads",
+		CreatedAt: time.Now().UTC(),
+	}
+	if err := archive.Archive(ctx, 7, "session-1", []*memory.MemoryEntry{entry}, "relevance"); err != nil {
+		t.Fatalf("Archive() error = %v", err)
+	}
+	var count int
+	if err := openCountQuery(store, &count); err != nil {
+		t.Fatalf("count archive rows: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("expected one archive row, got %d", count)
+	}
+}
+
+func openCountQuery(store memory.EvolvingMemoryStore, dest *int) error {
+	sqliteStore := store.(*sqliteEvolvingMemoryStore)
+	return sqliteStore.db.QueryRow(`SELECT COUNT(*) FROM evolving_memory_archive WHERE user_id = 7 AND session_id = 'session-1' AND reason = 'relevance'`).Scan(dest)
+}

--- a/internal/persistence/databases/evolving_memory_crud_postgres.go
+++ b/internal/persistence/databases/evolving_memory_crud_postgres.go
@@ -2,6 +2,7 @@ package databases
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"manifold/internal/agent/memory"
@@ -192,6 +193,39 @@ func (s *pgEvolvingMemoryStore) Delete(ctx context.Context, userID int64, sessio
 DELETE FROM evolving_memories
 WHERE user_id = $1 AND session_id = $2 AND id = ANY($3::uuid[])`, userID, sessionID, parsedIDs)
 	return err
+}
+
+func (s *pgEvolvingMemoryStore) Archive(ctx context.Context, userID int64, sessionID string, entries []*memory.MemoryEntry, reason string) error {
+	if s.pool == nil {
+		return errors.New("postgres evolving memory store requires pool")
+	}
+	if len(entries) == 0 {
+		return nil
+	}
+	sessionID = normalizeMemorySessionID(sessionID)
+	reason = strings.TrimSpace(reason)
+	archivedAt := time.Now().UTC()
+	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	for _, entry := range entries {
+		if entry == nil || strings.TrimSpace(entry.ID) == "" {
+			continue
+		}
+		payload, err := json.Marshal(entry)
+		if err != nil {
+			return err
+		}
+		if _, err := tx.Exec(ctx, `
+INSERT INTO evolving_memory_archive(id, original_id, user_id, session_id, reason, payload, archived_at)
+VALUES($1, $2, $3, $4, $5, $6::jsonb, $7)
+`, uuid.New(), strings.TrimSpace(entry.ID), userID, sessionID, reason, string(payload), archivedAt); err != nil {
+			return err
+		}
+	}
+	return tx.Commit(ctx)
 }
 
 // TouchAccess increments access counters for memory entries after retrieval.

--- a/internal/persistence/databases/evolving_memory_schema_postgres.go
+++ b/internal/persistence/databases/evolving_memory_schema_postgres.go
@@ -75,6 +75,18 @@ CREATE INDEX IF NOT EXISTS evolving_memories_user_scope_created_idx
 CREATE INDEX IF NOT EXISTS evolving_memories_expires_at_idx
 	ON evolving_memories(expires_at)
 	WHERE expires_at IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS evolving_memory_archive (
+	id UUID PRIMARY KEY,
+	original_id TEXT NOT NULL,
+	user_id BIGINT NOT NULL,
+	session_id TEXT NOT NULL,
+	reason TEXT NOT NULL DEFAULT '',
+	payload JSONB NOT NULL DEFAULT '{}'::jsonb,
+	archived_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS evolving_memory_archive_user_session_idx
+	ON evolving_memory_archive(user_id, session_id, archived_at DESC);
 `)
 	if err != nil {
 		return err

--- a/internal/persistence/databases/evolving_memory_store_sqlite.go
+++ b/internal/persistence/databases/evolving_memory_store_sqlite.go
@@ -3,6 +3,7 @@ package databases
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math"
@@ -60,6 +61,18 @@ CREATE INDEX IF NOT EXISTS evolving_memories_user_scope_idx
 	ON evolving_memories(user_id, scope);
 CREATE INDEX IF NOT EXISTS evolving_memories_expires_idx
 	ON evolving_memories(expires_at);
+
+CREATE TABLE IF NOT EXISTS evolving_memory_archive (
+	id TEXT PRIMARY KEY,
+	original_id TEXT NOT NULL,
+	user_id INTEGER NOT NULL,
+	session_id TEXT NOT NULL,
+	reason TEXT NOT NULL DEFAULT '',
+	payload TEXT NOT NULL CHECK(json_valid(payload)),
+	archived_at DATETIME NOT NULL
+);
+CREATE INDEX IF NOT EXISTS evolving_memory_archive_user_session_idx
+	ON evolving_memory_archive(user_id, session_id, archived_at);
 `)
 	return err
 }
@@ -184,6 +197,39 @@ func (s *sqliteEvolvingMemoryStore) Delete(ctx context.Context, userID int64, se
 DELETE FROM evolving_memories
 WHERE user_id = ? AND session_id = ? AND id IN (%s)`, inSQL), args...)
 	return err
+}
+
+func (s *sqliteEvolvingMemoryStore) Archive(ctx context.Context, userID int64, sessionID string, entries []*memory.MemoryEntry, reason string) error {
+	if err := s.Init(ctx); err != nil {
+		return err
+	}
+	if len(entries) == 0 {
+		return nil
+	}
+	sessionID = normalizeMemorySessionID(sessionID)
+	reason = strings.TrimSpace(reason)
+	archivedAt := time.Now().UTC()
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer rollbackQuietly(tx)
+	for _, entry := range entries {
+		if entry == nil || strings.TrimSpace(entry.ID) == "" {
+			continue
+		}
+		payload, err := json.Marshal(entry)
+		if err != nil {
+			return err
+		}
+		if _, err := tx.ExecContext(ctx, `
+INSERT INTO evolving_memory_archive(id, original_id, user_id, session_id, reason, payload, archived_at)
+VALUES(?, ?, ?, ?, ?, ?, ?)
+`, uuid.NewString(), strings.TrimSpace(entry.ID), userID, sessionID, reason, string(payload), archivedAt); err != nil {
+			return err
+		}
+	}
+	return tx.Commit()
 }
 
 func (s *sqliteEvolvingMemoryStore) TouchAccess(ctx context.Context, ids []string, at time.Time) error {

--- a/internal/persistence/databases/factory.go
+++ b/internal/persistence/databases/factory.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"manifold/internal/agent/memory/belief"
+	"manifold/internal/agent/memory/decision"
 	"manifold/internal/config"
 	"manifold/internal/durable"
 	"manifold/internal/persistence"
@@ -341,7 +342,10 @@ func initializeDefaultStores(ctx context.Context, m *Manager, cfg config.DBConfi
 	if err := initializeRuntimeDefaultStores(ctx, m, cfg, defaultBackend); err != nil {
 		return err
 	}
-	return initializeBeliefDefaultStore(ctx, m, cfg, defaultBackend)
+	if err := initializeBeliefDefaultStore(ctx, m, cfg, defaultBackend); err != nil {
+		return err
+	}
+	return initializeArchaeologyDefaultStores(ctx, m, cfg, defaultBackend)
 }
 
 func initializeMemoryDefaultStores(ctx context.Context, m *Manager, cfg config.DBConfig, defaultBackend string) error {
@@ -464,6 +468,22 @@ func initializeBeliefDefaultStore(ctx context.Context, m *Manager, cfg config.DB
 		})
 	}
 	return initStore(ctx, "belief store", m.Belief)
+}
+
+func initializeArchaeologyDefaultStores(ctx context.Context, m *Manager, cfg config.DBConfig, defaultBackend string) error {
+	if defaultBackend == "sqlite" {
+		m.Decision = NewSQLiteDecisionStore(m.SQLite)
+		m.Artifact = NewSQLiteArtifactStore(m.SQLite)
+	} else {
+		m.Decision = newStoreWithOptionalPool(ctx, cfg.DefaultDSN, func(pool *pgxpool.Pool) decision.Store {
+			return NewPostgresDecisionStoreWithDimensions(pool, cfg.Vector.Dimensions)
+		})
+		m.Artifact = newStoreWithOptionalPool(ctx, cfg.DefaultDSN, NewPostgresArtifactStore)
+	}
+	if err := initStore(ctx, "decision store", m.Decision); err != nil {
+		return err
+	}
+	return initStore(ctx, "artifact store", m.Artifact)
 }
 
 func resolveDefaultStoreBackend(cfg config.DBConfig, sqliteAvailable bool) string {

--- a/internal/persistence/databases/factory.go
+++ b/internal/persistence/databases/factory.go
@@ -13,6 +13,7 @@ import (
 	"manifold/internal/durable"
 	"manifold/internal/persistence"
 	sqlitep "manifold/internal/persistence/sqlite"
+	"manifold/internal/secrets"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 )
@@ -390,17 +391,29 @@ func initializePlaygroundDefaultStore(ctx context.Context, m *Manager, cfg confi
 }
 
 func initializeConfigDefaultStores(ctx context.Context, m *Manager, cfg config.DBConfig, defaultBackend string) error {
+	var codec secrets.Codec
+	if defaultBackend == "sqlite" || strings.TrimSpace(cfg.DefaultDSN) != "" {
+		var err error
+		codec, err = databaseSecretCodec(nil)
+		if err != nil {
+			return err
+		}
+	}
 	if defaultBackend == "sqlite" {
-		m.Specialists = NewSQLiteSpecialistsStore(m.SQLite)
+		m.Specialists = NewSQLiteSpecialistsStoreWithCodec(m.SQLite, codec)
 		m.SpecialistTeams = NewSQLiteSpecialistTeamsStore(m.SQLite)
-		m.MCP = NewSQLiteMCPStore(m.SQLite)
+		m.MCP = NewSQLiteMCPStoreWithCodec(m.SQLite, codec)
 		m.Projects = NewSQLiteProjectsStore(m.SQLite)
 		m.UserPreferences = NewSQLiteUserPreferencesStore(m.SQLite)
 		m.CommandPolicy = NewSQLiteCommandPolicyStore(m.SQLite)
 	} else {
-		m.Specialists = newStoreWithOptionalPool(ctx, cfg.DefaultDSN, NewSpecialistsStore)
+		m.Specialists = newStoreWithOptionalPool(ctx, cfg.DefaultDSN, func(pool *pgxpool.Pool) persistence.SpecialistsStore {
+			return NewSpecialistsStoreWithCodec(pool, codec)
+		})
 		m.SpecialistTeams = newStoreWithOptionalPool(ctx, cfg.DefaultDSN, NewSpecialistTeamsStore)
-		m.MCP = newStoreWithOptionalPool(ctx, cfg.DefaultDSN, NewMCPStore)
+		m.MCP = newStoreWithOptionalPool(ctx, cfg.DefaultDSN, func(pool *pgxpool.Pool) persistence.MCPStore {
+			return NewMCPStoreWithCodec(pool, codec)
+		})
 		m.Projects = newStoreWithOptionalPool(ctx, cfg.DefaultDSN, NewPostgresProjectsStore)
 		m.UserPreferences = newStoreWithOptionalPool(ctx, cfg.DefaultDSN, NewUserPreferencesStore)
 		m.CommandPolicy = newStoreWithOptionalPool(ctx, cfg.DefaultDSN, NewCommandPolicyStore)

--- a/internal/persistence/databases/interfaces.go
+++ b/internal/persistence/databases/interfaces.go
@@ -6,7 +6,9 @@ import (
 	"reflect"
 
 	"manifold/internal/agent/memory"
+	"manifold/internal/agent/memory/artifact"
 	"manifold/internal/agent/memory/belief"
+	"manifold/internal/agent/memory/decision"
 	"manifold/internal/durable"
 	"manifold/internal/persistence"
 	"manifold/internal/transit"
@@ -82,6 +84,8 @@ type Manager struct {
 	MatrixMessages     persistence.MatrixMessageStore
 	Transit            transit.Store
 	Belief             belief.Store
+	Decision           decision.Store
+	Artifact           artifact.Store
 }
 
 // Close attempts to close any underlying pools. It's a no-op for memory backends.
@@ -106,6 +110,8 @@ func (m Manager) Close() {
 	closeIfPossible(m.MatrixMessages)
 	closeIfPossible(m.Transit)
 	closeIfPossible(m.Belief)
+	closeIfPossible(m.Decision)
+	closeIfPossible(m.Artifact)
 }
 
 func closeIfPossible(value any) {

--- a/internal/persistence/databases/mcp_store.go
+++ b/internal/persistence/databases/mcp_store.go
@@ -2,13 +2,16 @@ package databases
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 	"sync"
 	"time"
 
 	"manifold/internal/persistence"
+	"manifold/internal/secrets"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 )
@@ -19,6 +22,13 @@ func NewMCPStore(pool *pgxpool.Pool) persistence.MCPStore {
 		return &memMCPStore{m: map[int64]map[string]persistence.MCPServer{}}
 	}
 	return &pgMCPStore{pool: pool}
+}
+
+func NewMCPStoreWithCodec(pool *pgxpool.Pool, codec secrets.Codec) persistence.MCPStore {
+	if pool == nil {
+		return &memMCPStore{m: map[int64]map[string]persistence.MCPServer{}}
+	}
+	return &pgMCPStore{pool: pool, codec: codec}
 }
 
 type memMCPStore struct {
@@ -91,12 +101,18 @@ func (s *memMCPStore) Delete(ctx context.Context, userID int64, name string) err
 }
 
 type pgMCPStore struct {
-	pool *pgxpool.Pool
+	pool  *pgxpool.Pool
+	codec secrets.Codec
 }
 
 func (s *pgMCPStore) Init(ctx context.Context) error {
-	_, err := s.pool.Exec(ctx, `
-CREATE TABLE IF NOT EXISTS mcp_servers (
+	codec, err := databaseSecretCodec(s.codec)
+	if err != nil {
+		return err
+	}
+	s.codec = codec
+	_, err = s.pool.Exec(ctx, `
+	CREATE TABLE IF NOT EXISTS mcp_servers (
 	id SERIAL PRIMARY KEY,
 	user_id BIGINT NOT NULL DEFAULT 0,
 	name TEXT NOT NULL,
@@ -130,10 +146,15 @@ CREATE TABLE IF NOT EXISTS mcp_servers (
 	if _, err := s.pool.Exec(ctx, `ALTER TABLE mcp_servers ADD COLUMN IF NOT EXISTS oauth_client_secret TEXT NOT NULL DEFAULT ''`); err != nil {
 		return err
 	}
-	return nil
+	return backfillPostgresMCPSecrets(ctx, s.pool, codec)
 }
 
 func (s *pgMCPStore) List(ctx context.Context, userID int64) ([]persistence.MCPServer, error) {
+	codec, err := databaseSecretCodec(s.codec)
+	if err != nil {
+		return nil, err
+	}
+	s.codec = codec
 	rows, err := s.pool.Query(ctx, `
 		SELECT id, user_id, name, command, args, env, url, headers, bearer_token, origin, protocol_version, keep_alive_seconds, disabled, oauth_provider, oauth_client_id, oauth_client_secret, oauth_access_token, oauth_refresh_token, oauth_expires_at, oauth_scopes
 		FROM mcp_servers WHERE user_id = $1 ORDER BY name ASC
@@ -161,17 +182,26 @@ func (s *pgMCPStore) List(ctx context.Context, userID int64) ([]persistence.MCPS
 		if expiresAt != nil {
 			srv.OAuthExpiresAt = *expiresAt
 		}
+		srv, err = decryptMCPServerFromStore(codec, srv)
+		if err != nil {
+			return nil, err
+		}
 		out = append(out, srv)
 	}
-	return out, nil
+	return out, rows.Err()
 }
 
 func (s *pgMCPStore) GetByName(ctx context.Context, userID int64, name string) (persistence.MCPServer, bool, error) {
+	codec, err := databaseSecretCodec(s.codec)
+	if err != nil {
+		return persistence.MCPServer{}, false, err
+	}
+	s.codec = codec
 	var srv persistence.MCPServer
 	var args, env, headers, scopes []byte
 	var expiresAt *time.Time
 
-	err := s.pool.QueryRow(ctx, `
+	err = s.pool.QueryRow(ctx, `
 		SELECT id, user_id, name, command, args, env, url, headers, bearer_token, origin, protocol_version, keep_alive_seconds, disabled, oauth_provider, oauth_client_id, oauth_client_secret, oauth_access_token, oauth_refresh_token, oauth_expires_at, oauth_scopes
 		FROM mcp_servers WHERE user_id = $1 AND name = $2
 	`, userID, name).Scan(
@@ -187,21 +217,34 @@ func (s *pgMCPStore) GetByName(ctx context.Context, userID int64, name string) (
 	if expiresAt != nil {
 		srv.OAuthExpiresAt = *expiresAt
 	}
+	srv, err = decryptMCPServerFromStore(codec, srv)
+	if err != nil {
+		return persistence.MCPServer{}, false, err
+	}
 	return srv, true, nil
 }
 
 func (s *pgMCPStore) Upsert(ctx context.Context, userID int64, srv persistence.MCPServer) (persistence.MCPServer, error) {
+	codec, err := databaseSecretCodec(s.codec)
+	if err != nil {
+		return persistence.MCPServer{}, err
+	}
+	s.codec = codec
+	toStore, err := encryptMCPServerForStore(s.codec, userID, srv)
+	if err != nil {
+		return persistence.MCPServer{}, err
+	}
 	args, _ := json.Marshal(srv.Args)
-	env, _ := json.Marshal(srv.Env)
-	headers, _ := json.Marshal(srv.Headers)
+	env, _ := json.Marshal(toStore.Env)
+	headers, _ := json.Marshal(toStore.Headers)
 	scopes, _ := json.Marshal(srv.OAuthScopes)
 	var expiresAt *time.Time
 	if !srv.OAuthExpiresAt.IsZero() {
 		expiresAt = &srv.OAuthExpiresAt
 	}
 
-	err := s.pool.QueryRow(ctx, `
-		INSERT INTO mcp_servers (user_id, name, command, args, env, url, headers, bearer_token, origin, protocol_version, keep_alive_seconds, disabled, oauth_provider, oauth_client_id, oauth_client_secret, oauth_access_token, oauth_refresh_token, oauth_expires_at, oauth_scopes)
+	err = s.pool.QueryRow(ctx, `
+			INSERT INTO mcp_servers (user_id, name, command, args, env, url, headers, bearer_token, origin, protocol_version, keep_alive_seconds, disabled, oauth_provider, oauth_client_id, oauth_client_secret, oauth_access_token, oauth_refresh_token, oauth_expires_at, oauth_scopes)
 		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19)
 		ON CONFLICT (user_id, name) DO UPDATE SET
 			command = EXCLUDED.command,
@@ -221,8 +264,8 @@ func (s *pgMCPStore) Upsert(ctx context.Context, userID int64, srv persistence.M
 			oauth_refresh_token = EXCLUDED.oauth_refresh_token,
 			oauth_expires_at = EXCLUDED.oauth_expires_at,
 			oauth_scopes = EXCLUDED.oauth_scopes
-		RETURNING id
-	`, userID, srv.Name, srv.Command, args, env, srv.URL, headers, srv.BearerToken, srv.Origin, srv.ProtocolVersion, srv.KeepAliveSeconds, srv.Disabled, srv.OAuthProvider, srv.OAuthClientID, srv.OAuthClientSecret, srv.OAuthAccessToken, srv.OAuthRefreshToken, expiresAt, scopes).Scan(&srv.ID)
+			RETURNING id
+		`, userID, srv.Name, srv.Command, args, env, srv.URL, headers, toStore.BearerToken, srv.Origin, srv.ProtocolVersion, srv.KeepAliveSeconds, srv.Disabled, srv.OAuthProvider, srv.OAuthClientID, toStore.OAuthClientSecret, toStore.OAuthAccessToken, toStore.OAuthRefreshToken, expiresAt, scopes).Scan(&srv.ID)
 
 	srv.UserID = userID
 	return srv, err
@@ -231,4 +274,150 @@ func (s *pgMCPStore) Upsert(ctx context.Context, userID int64, srv persistence.M
 func (s *pgMCPStore) Delete(ctx context.Context, userID int64, name string) error {
 	_, err := s.pool.Exec(ctx, "DELETE FROM mcp_servers WHERE user_id = $1 AND name = $2", userID, name)
 	return err
+}
+
+type mcpSecretRecord struct {
+	ID                int64
+	UserID            int64
+	Name              string
+	Env               map[string]string
+	Headers           map[string]string
+	BearerToken       string
+	OAuthClientSecret string
+	OAuthAccessToken  string
+	OAuthRefreshToken string
+}
+
+func backfillPostgresMCPSecrets(ctx context.Context, pool *pgxpool.Pool, codec secrets.Codec) error {
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	rows, err := tx.Query(ctx, `SELECT id, user_id, name, env, headers, bearer_token, oauth_client_secret, oauth_access_token, oauth_refresh_token FROM mcp_servers`)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+	records, err := scanMCPSecretRecords(rows)
+	if err != nil {
+		return err
+	}
+
+	for _, record := range records {
+		if !mcpRecordNeedsBackfill(codec, record) {
+			continue
+		}
+		encrypted, err := encryptMCPServerForStore(codec, record.UserID, persistence.MCPServer{
+			UserID:            record.UserID,
+			Name:              record.Name,
+			Env:               record.Env,
+			Headers:           record.Headers,
+			BearerToken:       record.BearerToken,
+			OAuthClientSecret: record.OAuthClientSecret,
+			OAuthAccessToken:  record.OAuthAccessToken,
+			OAuthRefreshToken: record.OAuthRefreshToken,
+		})
+		if err != nil {
+			return fmt.Errorf("backfill mcp secrets id=%d: %w", record.ID, err)
+		}
+		env, _ := json.Marshal(encrypted.Env)
+		headers, _ := json.Marshal(encrypted.Headers)
+		if _, err := tx.Exec(ctx, `UPDATE mcp_servers SET env = $1, headers = $2, bearer_token = $3, oauth_client_secret = $4, oauth_access_token = $5, oauth_refresh_token = $6 WHERE id = $7`,
+			env, headers, encrypted.BearerToken, encrypted.OAuthClientSecret, encrypted.OAuthAccessToken, encrypted.OAuthRefreshToken, record.ID); err != nil {
+			return fmt.Errorf("update mcp secret backfill id=%d: %w", record.ID, err)
+		}
+	}
+	return tx.Commit(ctx)
+}
+
+func backfillSQLiteMCPSecrets(ctx context.Context, db *sql.DB, codec secrets.Codec) error {
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	rows, err := tx.QueryContext(ctx, `SELECT id, user_id, name, env, headers, bearer_token, oauth_client_secret, oauth_access_token, oauth_refresh_token FROM mcp_servers`)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = rows.Close() }()
+	records, err := scanMCPSecretRecords(rows)
+	if err != nil {
+		return err
+	}
+
+	for _, record := range records {
+		if !mcpRecordNeedsBackfill(codec, record) {
+			continue
+		}
+		encrypted, err := encryptMCPServerForStore(codec, record.UserID, persistence.MCPServer{
+			UserID:            record.UserID,
+			Name:              record.Name,
+			Env:               record.Env,
+			Headers:           record.Headers,
+			BearerToken:       record.BearerToken,
+			OAuthClientSecret: record.OAuthClientSecret,
+			OAuthAccessToken:  record.OAuthAccessToken,
+			OAuthRefreshToken: record.OAuthRefreshToken,
+		})
+		if err != nil {
+			return fmt.Errorf("backfill mcp secrets id=%d: %w", record.ID, err)
+		}
+		env, _ := json.Marshal(encrypted.Env)
+		headers, _ := json.Marshal(encrypted.Headers)
+		if _, err := tx.ExecContext(ctx, `UPDATE mcp_servers SET env = ?, headers = ?, bearer_token = ?, oauth_client_secret = ?, oauth_access_token = ?, oauth_refresh_token = ? WHERE id = ?`,
+			string(env), string(headers), encrypted.BearerToken, encrypted.OAuthClientSecret, encrypted.OAuthAccessToken, encrypted.OAuthRefreshToken, record.ID); err != nil {
+			return fmt.Errorf("update mcp secret backfill id=%d: %w", record.ID, err)
+		}
+	}
+	return tx.Commit()
+}
+
+func scanMCPSecretRecords(rows interface {
+	Next() bool
+	Scan(dest ...any) error
+	Err() error
+}) ([]mcpSecretRecord, error) {
+	var records []mcpSecretRecord
+	for rows.Next() {
+		var record mcpSecretRecord
+		var env, headers []byte
+		if err := rows.Scan(&record.ID, &record.UserID, &record.Name, &env, &headers, &record.BearerToken, &record.OAuthClientSecret, &record.OAuthAccessToken, &record.OAuthRefreshToken); err != nil {
+			return nil, err
+		}
+		if len(env) > 0 {
+			if err := json.Unmarshal(env, &record.Env); err != nil {
+				return nil, fmt.Errorf("mcp env id=%d: %w", record.ID, err)
+			}
+		}
+		if len(headers) > 0 {
+			if err := json.Unmarshal(headers, &record.Headers); err != nil {
+				return nil, fmt.Errorf("mcp headers id=%d: %w", record.ID, err)
+			}
+		}
+		records = append(records, record)
+	}
+	return records, rows.Err()
+}
+
+func mcpRecordNeedsBackfill(codec secrets.Codec, record mcpSecretRecord) bool {
+	for _, value := range []string{record.BearerToken, record.OAuthClientSecret, record.OAuthAccessToken, record.OAuthRefreshToken} {
+		if value != "" && !codec.IsSealed(value) {
+			return true
+		}
+	}
+	for _, value := range record.Headers {
+		if value != "" && !codec.IsSealed(value) {
+			return true
+		}
+	}
+	for key, value := range record.Env {
+		if isSecretMapKey(key) && value != "" && !codec.IsSealed(value) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/persistence/databases/secrets.go
+++ b/internal/persistence/databases/secrets.go
@@ -1,0 +1,207 @@
+package databases
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"manifold/internal/persistence"
+	"manifold/internal/secrets"
+)
+
+var secretMapKeyPattern = regexp.MustCompile(`(?i)(^|[_\-.])(api[_\-.]?key|key|secret|token|password|credential|auth)([_\-.]|$)`)
+
+func databaseSecretCodec(codec secrets.Codec) (secrets.Codec, error) {
+	if codec != nil {
+		return codec, nil
+	}
+	return secrets.NewCodecFromEnv()
+}
+
+func specialistSecretAAD(userID int64, name, field string) string {
+	return fmt.Sprintf("specialists/%d/%s/%s", userID, name, field)
+}
+
+func mcpSecretAAD(userID int64, name, field string) string {
+	return fmt.Sprintf("mcp_servers/%d/%s/%s", userID, name, field)
+}
+
+func secretSubfieldAAD(base, key string) string {
+	return base + "/" + key
+}
+
+func sealSecretString(codec secrets.Codec, value, aad, label string) (string, error) {
+	sealed, err := codec.SealString(value, aad)
+	if err != nil {
+		return "", fmt.Errorf("encrypt %s: %w", label, err)
+	}
+	return sealed, nil
+}
+
+func openSecretString(codec secrets.Codec, value, aad, label string) (string, error) {
+	opened, err := codec.OpenString(value, aad)
+	if err != nil {
+		return "", fmt.Errorf("decrypt %s: %w", label, err)
+	}
+	return opened, nil
+}
+
+func sealAllStringMap(codec secrets.Codec, in map[string]string, aadBase, label string) (map[string]string, error) {
+	if in == nil {
+		return nil, nil
+	}
+	out := make(map[string]string, len(in))
+	for key, value := range in {
+		sealed, err := sealSecretString(codec, value, secretSubfieldAAD(aadBase, key), label+"."+key)
+		if err != nil {
+			return nil, err
+		}
+		out[key] = sealed
+	}
+	return out, nil
+}
+
+func openAllStringMap(codec secrets.Codec, in map[string]string, aadBase, label string) (map[string]string, error) {
+	if in == nil {
+		return nil, nil
+	}
+	out := make(map[string]string, len(in))
+	for key, value := range in {
+		opened, err := openSecretString(codec, value, secretSubfieldAAD(aadBase, key), label+"."+key)
+		if err != nil {
+			return nil, err
+		}
+		out[key] = opened
+	}
+	return out, nil
+}
+
+func sealSensitiveStringMap(codec secrets.Codec, in map[string]string, aadBase, label string) (map[string]string, error) {
+	if in == nil {
+		return nil, nil
+	}
+	out := make(map[string]string, len(in))
+	for key, value := range in {
+		if isSecretMapKey(key) {
+			sealed, err := sealSecretString(codec, value, secretSubfieldAAD(aadBase, key), label+"."+key)
+			if err != nil {
+				return nil, err
+			}
+			out[key] = sealed
+			continue
+		}
+		out[key] = value
+	}
+	return out, nil
+}
+
+func openSensitiveStringMap(codec secrets.Codec, in map[string]string, aadBase, label string) (map[string]string, error) {
+	if in == nil {
+		return nil, nil
+	}
+	out := make(map[string]string, len(in))
+	for key, value := range in {
+		if isSecretMapKey(key) {
+			opened, err := openSecretString(codec, value, secretSubfieldAAD(aadBase, key), label+"."+key)
+			if err != nil {
+				return nil, err
+			}
+			out[key] = opened
+			continue
+		}
+		out[key] = value
+	}
+	return out, nil
+}
+
+func isSecretMapKey(key string) bool {
+	return secretMapKeyPattern.MatchString(strings.TrimSpace(key))
+}
+
+func encryptSpecialistForStore(codec secrets.Codec, userID int64, sp persistence.Specialist) (persistence.Specialist, error) {
+	out := sp
+	var err error
+	out.APIKey, err = sealSecretString(codec, sp.APIKey, specialistSecretAAD(userID, sp.Name, "api_key"), "specialist api_key")
+	if err != nil {
+		return persistence.Specialist{}, err
+	}
+	out.ExtraHeaders, err = sealAllStringMap(codec, sp.ExtraHeaders, specialistSecretAAD(userID, sp.Name, "extra_headers"), "specialist extra_headers")
+	if err != nil {
+		return persistence.Specialist{}, err
+	}
+	return out, nil
+}
+
+func decryptSpecialistFromStore(codec secrets.Codec, sp persistence.Specialist) (persistence.Specialist, error) {
+	out := sp
+	var err error
+	out.APIKey, err = openSecretString(codec, sp.APIKey, specialistSecretAAD(sp.UserID, sp.Name, "api_key"), "specialist api_key")
+	if err != nil {
+		return persistence.Specialist{}, err
+	}
+	out.ExtraHeaders, err = openAllStringMap(codec, sp.ExtraHeaders, specialistSecretAAD(sp.UserID, sp.Name, "extra_headers"), "specialist extra_headers")
+	if err != nil {
+		return persistence.Specialist{}, err
+	}
+	return out, nil
+}
+
+func encryptMCPServerForStore(codec secrets.Codec, userID int64, srv persistence.MCPServer) (persistence.MCPServer, error) {
+	out := srv
+	var err error
+	out.BearerToken, err = sealSecretString(codec, srv.BearerToken, mcpSecretAAD(userID, srv.Name, "bearer_token"), "mcp bearer_token")
+	if err != nil {
+		return persistence.MCPServer{}, err
+	}
+	out.OAuthClientSecret, err = sealSecretString(codec, srv.OAuthClientSecret, mcpSecretAAD(userID, srv.Name, "oauth_client_secret"), "mcp oauth_client_secret")
+	if err != nil {
+		return persistence.MCPServer{}, err
+	}
+	out.OAuthAccessToken, err = sealSecretString(codec, srv.OAuthAccessToken, mcpSecretAAD(userID, srv.Name, "oauth_access_token"), "mcp oauth_access_token")
+	if err != nil {
+		return persistence.MCPServer{}, err
+	}
+	out.OAuthRefreshToken, err = sealSecretString(codec, srv.OAuthRefreshToken, mcpSecretAAD(userID, srv.Name, "oauth_refresh_token"), "mcp oauth_refresh_token")
+	if err != nil {
+		return persistence.MCPServer{}, err
+	}
+	out.Headers, err = sealAllStringMap(codec, srv.Headers, mcpSecretAAD(userID, srv.Name, "headers"), "mcp headers")
+	if err != nil {
+		return persistence.MCPServer{}, err
+	}
+	out.Env, err = sealSensitiveStringMap(codec, srv.Env, mcpSecretAAD(userID, srv.Name, "env"), "mcp env")
+	if err != nil {
+		return persistence.MCPServer{}, err
+	}
+	return out, nil
+}
+
+func decryptMCPServerFromStore(codec secrets.Codec, srv persistence.MCPServer) (persistence.MCPServer, error) {
+	out := srv
+	var err error
+	out.BearerToken, err = openSecretString(codec, srv.BearerToken, mcpSecretAAD(srv.UserID, srv.Name, "bearer_token"), "mcp bearer_token")
+	if err != nil {
+		return persistence.MCPServer{}, err
+	}
+	out.OAuthClientSecret, err = openSecretString(codec, srv.OAuthClientSecret, mcpSecretAAD(srv.UserID, srv.Name, "oauth_client_secret"), "mcp oauth_client_secret")
+	if err != nil {
+		return persistence.MCPServer{}, err
+	}
+	out.OAuthAccessToken, err = openSecretString(codec, srv.OAuthAccessToken, mcpSecretAAD(srv.UserID, srv.Name, "oauth_access_token"), "mcp oauth_access_token")
+	if err != nil {
+		return persistence.MCPServer{}, err
+	}
+	out.OAuthRefreshToken, err = openSecretString(codec, srv.OAuthRefreshToken, mcpSecretAAD(srv.UserID, srv.Name, "oauth_refresh_token"), "mcp oauth_refresh_token")
+	if err != nil {
+		return persistence.MCPServer{}, err
+	}
+	out.Headers, err = openAllStringMap(codec, srv.Headers, mcpSecretAAD(srv.UserID, srv.Name, "headers"), "mcp headers")
+	if err != nil {
+		return persistence.MCPServer{}, err
+	}
+	out.Env, err = openSensitiveStringMap(codec, srv.Env, mcpSecretAAD(srv.UserID, srv.Name, "env"), "mcp env")
+	if err != nil {
+		return persistence.MCPServer{}, err
+	}
+	return out, nil
+}

--- a/internal/persistence/databases/secrets_store_test.go
+++ b/internal/persistence/databases/secrets_store_test.go
@@ -1,0 +1,456 @@
+package databases
+
+import (
+	"context"
+	"database/sql"
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"manifold/internal/config"
+	"manifold/internal/persistence"
+	"manifold/internal/secrets"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func testDatabaseSecretsCodec(t *testing.T) secrets.Codec {
+	t.Helper()
+	key := make([]byte, 32)
+	for i := range key {
+		key[i] = byte(i + 11)
+	}
+	codec, err := secrets.NewCodec(key)
+	if err != nil {
+		t.Fatalf("NewCodec: %v", err)
+	}
+	return codec
+}
+
+func testSecretsKey(t *testing.T) string {
+	t.Helper()
+	key := make([]byte, 32)
+	for i := range key {
+		key[i] = byte(i + 31)
+	}
+	return base64.StdEncoding.EncodeToString(key)
+}
+
+func testPostgresDSN() string {
+	dsn := strings.TrimSpace(os.Getenv("MANIFOLD_TEST_POSTGRES_DSN"))
+	if dsn == "" {
+		dsn = strings.TrimSpace(os.Getenv("POSTGRES_TEST_DSN"))
+	}
+	return dsn
+}
+
+func TestSQLiteSpecialistsStoreEncryptsAndBackfillsSecrets(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	db := openTestSQLite(t)
+	codec := testDatabaseSecretsCodec(t)
+	store := NewSQLiteSpecialistsStoreWithCodec(db, codec)
+	if err := store.Init(ctx); err != nil {
+		t.Fatalf("init store: %v", err)
+	}
+
+	if _, err := store.Upsert(ctx, 7, persistence.Specialist{
+		Name:         "writer",
+		Provider:     "openai",
+		APIKey:       "sk-specialist",
+		ExtraHeaders: map[string]string{"Authorization": "Bearer specialist-header"},
+		Model:        "gpt-5-mini",
+	}); err != nil {
+		t.Fatalf("upsert specialist: %v", err)
+	}
+
+	rawAPIKey, rawHeaders := rawSQLiteSpecialistSecrets(t, db, 7, "writer")
+	if !codec.IsSealed(rawAPIKey) || strings.Contains(rawAPIKey, "sk-specialist") {
+		t.Fatalf("expected encrypted api key, got %q", rawAPIKey)
+	}
+	if !codec.IsSealed(rawHeaders["Authorization"]) || strings.Contains(rawHeaders["Authorization"], "specialist-header") {
+		t.Fatalf("expected encrypted header, got %q", rawHeaders["Authorization"])
+	}
+
+	got, ok, err := store.GetByName(ctx, 7, "writer")
+	if err != nil {
+		t.Fatalf("get specialist: %v", err)
+	}
+	if !ok || got.APIKey != "sk-specialist" || got.ExtraHeaders["Authorization"] != "Bearer specialist-header" {
+		t.Fatalf("unexpected decrypted specialist: ok=%v got=%+v", ok, got)
+	}
+
+	if err := store.Init(ctx); err != nil {
+		t.Fatalf("re-init store: %v", err)
+	}
+	afterAPIKey, afterHeaders := rawSQLiteSpecialistSecrets(t, db, 7, "writer")
+	if afterAPIKey != rawAPIKey || afterHeaders["Authorization"] != rawHeaders["Authorization"] {
+		t.Fatalf("already encrypted specialist row was modified by backfill")
+	}
+
+	if _, err := db.ExecContext(ctx, `
+INSERT INTO specialists(user_id, name, api_key, extra_headers)
+VALUES(?, ?, ?, ?)`, 7, "legacy", "legacy-specialist-key", `{"Authorization":"Bearer legacy-header"}`); err != nil {
+		t.Fatalf("insert legacy specialist row: %v", err)
+	}
+	legacyStore := NewSQLiteSpecialistsStoreWithCodec(db, codec)
+	if err := legacyStore.Init(ctx); err != nil {
+		t.Fatalf("backfill legacy specialist: %v", err)
+	}
+	legacyAPIKey, legacyHeaders := rawSQLiteSpecialistSecrets(t, db, 7, "legacy")
+	if !codec.IsSealed(legacyAPIKey) || !codec.IsSealed(legacyHeaders["Authorization"]) {
+		t.Fatalf("expected legacy specialist row to be encrypted, api=%q headers=%+v", legacyAPIKey, legacyHeaders)
+	}
+	legacy, ok, err := legacyStore.GetByName(ctx, 7, "legacy")
+	if err != nil {
+		t.Fatalf("get legacy specialist: %v", err)
+	}
+	if !ok || legacy.APIKey != "legacy-specialist-key" || legacy.ExtraHeaders["Authorization"] != "Bearer legacy-header" {
+		t.Fatalf("unexpected legacy specialist after backfill: ok=%v got=%+v", ok, legacy)
+	}
+}
+
+func TestSQLiteMCPStoreEncryptsAndBackfillsSecrets(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	db := openTestSQLite(t)
+	codec := testDatabaseSecretsCodec(t)
+	store := NewSQLiteMCPStoreWithCodec(db, codec)
+	if err := store.Init(ctx); err != nil {
+		t.Fatalf("init store: %v", err)
+	}
+
+	if _, err := store.Upsert(ctx, 7, persistence.MCPServer{
+		Name:              "remote",
+		URL:               "https://mcp.example.test",
+		Headers:           map[string]string{"Authorization": "Bearer mcp-header"},
+		BearerToken:       "bearer-secret",
+		OAuthProvider:     "custom",
+		OAuthClientID:     "public-client-id",
+		OAuthClientSecret: "client-secret",
+		OAuthAccessToken:  "access-token",
+		OAuthRefreshToken: "refresh-token",
+		OAuthExpiresAt:    time.Now().UTC().Add(time.Hour),
+		OAuthScopes:       []string{"tools.read"},
+		Env:               map[string]string{"OPENAI_API_KEY": "env-secret", "PATH": "/usr/bin"},
+	}); err != nil {
+		t.Fatalf("upsert mcp: %v", err)
+	}
+
+	raw := rawSQLiteMCPSecrets(t, db, 7, "remote")
+	assertSealedValue(t, codec, raw.bearerToken, "bearer-secret")
+	assertSealedValue(t, codec, raw.oauthClientSecret, "client-secret")
+	assertSealedValue(t, codec, raw.oauthAccessToken, "access-token")
+	assertSealedValue(t, codec, raw.oauthRefreshToken, "refresh-token")
+	assertSealedValue(t, codec, raw.headers["Authorization"], "mcp-header")
+	assertSealedValue(t, codec, raw.env["OPENAI_API_KEY"], "env-secret")
+	if raw.env["PATH"] != "/usr/bin" {
+		t.Fatalf("expected non-secret env key to remain plaintext, got %q", raw.env["PATH"])
+	}
+
+	got, ok, err := store.GetByName(ctx, 7, "remote")
+	if err != nil {
+		t.Fatalf("get mcp: %v", err)
+	}
+	if !ok || got.BearerToken != "bearer-secret" || got.OAuthClientSecret != "client-secret" || got.OAuthAccessToken != "access-token" || got.OAuthRefreshToken != "refresh-token" {
+		t.Fatalf("unexpected decrypted mcp server: ok=%v got=%+v", ok, got)
+	}
+	if got.Headers["Authorization"] != "Bearer mcp-header" || got.Env["OPENAI_API_KEY"] != "env-secret" || got.Env["PATH"] != "/usr/bin" {
+		t.Fatalf("unexpected decrypted mcp maps: headers=%+v env=%+v", got.Headers, got.Env)
+	}
+
+	if err := store.Init(ctx); err != nil {
+		t.Fatalf("re-init store: %v", err)
+	}
+	after := rawSQLiteMCPSecrets(t, db, 7, "remote")
+	if after.bearerToken != raw.bearerToken || after.headers["Authorization"] != raw.headers["Authorization"] || after.env["OPENAI_API_KEY"] != raw.env["OPENAI_API_KEY"] {
+		t.Fatalf("already encrypted mcp row was modified by backfill")
+	}
+
+	if _, err := db.ExecContext(ctx, `
+INSERT INTO mcp_servers(user_id, name, url, headers, env, bearer_token, oauth_client_secret, oauth_access_token, oauth_refresh_token)
+VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?)`, 7, "legacy", "https://legacy.example.test", `{"Authorization":"Bearer legacy-header"}`, `{"OPENAI_API_KEY":"legacy-env","PATH":"/bin"}`, "legacy-bearer", "legacy-client", "legacy-access", "legacy-refresh"); err != nil {
+		t.Fatalf("insert legacy mcp row: %v", err)
+	}
+	legacyStore := NewSQLiteMCPStoreWithCodec(db, codec)
+	if err := legacyStore.Init(ctx); err != nil {
+		t.Fatalf("backfill legacy mcp: %v", err)
+	}
+	legacyRaw := rawSQLiteMCPSecrets(t, db, 7, "legacy")
+	assertSealedValue(t, codec, legacyRaw.bearerToken, "legacy-bearer")
+	assertSealedValue(t, codec, legacyRaw.oauthClientSecret, "legacy-client")
+	assertSealedValue(t, codec, legacyRaw.oauthAccessToken, "legacy-access")
+	assertSealedValue(t, codec, legacyRaw.oauthRefreshToken, "legacy-refresh")
+	assertSealedValue(t, codec, legacyRaw.headers["Authorization"], "legacy-header")
+	assertSealedValue(t, codec, legacyRaw.env["OPENAI_API_KEY"], "legacy-env")
+	if legacyRaw.env["PATH"] != "/bin" {
+		t.Fatalf("expected legacy non-secret env key to remain plaintext, got %q", legacyRaw.env["PATH"])
+	}
+	legacy, ok, err := legacyStore.GetByName(ctx, 7, "legacy")
+	if err != nil {
+		t.Fatalf("get legacy mcp: %v", err)
+	}
+	if !ok || legacy.BearerToken != "legacy-bearer" || legacy.OAuthAccessToken != "legacy-access" || legacy.OAuthRefreshToken != "legacy-refresh" {
+		t.Fatalf("unexpected legacy mcp after backfill: ok=%v got=%+v", ok, legacy)
+	}
+}
+
+func TestPostgresSpecialistsStoreEncryptsAndBackfillsSecrets(t *testing.T) {
+	t.Parallel()
+
+	dsn := testPostgresDSN()
+	if dsn == "" {
+		t.Skip("set MANIFOLD_TEST_POSTGRES_DSN or POSTGRES_TEST_DSN to run Postgres specialist encryption tests")
+	}
+	ctx := context.Background()
+	pool := openTestPostgresSchema(t, dsn)
+	codec := testDatabaseSecretsCodec(t)
+	store := NewSpecialistsStoreWithCodec(pool, codec)
+	if err := store.Init(ctx); err != nil {
+		t.Fatalf("init store: %v", err)
+	}
+
+	if _, err := store.Upsert(ctx, 7, persistence.Specialist{
+		Name:         "writer",
+		Provider:     "openai",
+		APIKey:       "sk-specialist",
+		ExtraHeaders: map[string]string{"Authorization": "Bearer specialist-header"},
+		Model:        "gpt-5-mini",
+	}); err != nil {
+		t.Fatalf("upsert specialist: %v", err)
+	}
+	rawAPIKey, rawHeaders := rawPostgresSpecialistSecrets(t, pool, 7, "writer")
+	assertSealedValue(t, codec, rawAPIKey, "sk-specialist")
+	assertSealedValue(t, codec, rawHeaders["Authorization"], "specialist-header")
+
+	got, ok, err := store.GetByName(ctx, 7, "writer")
+	if err != nil {
+		t.Fatalf("get specialist: %v", err)
+	}
+	if !ok || got.APIKey != "sk-specialist" || got.ExtraHeaders["Authorization"] != "Bearer specialist-header" {
+		t.Fatalf("unexpected decrypted specialist: ok=%v got=%+v", ok, got)
+	}
+
+	if err := store.Init(ctx); err != nil {
+		t.Fatalf("re-init store: %v", err)
+	}
+	afterAPIKey, afterHeaders := rawPostgresSpecialistSecrets(t, pool, 7, "writer")
+	if afterAPIKey != rawAPIKey || afterHeaders["Authorization"] != rawHeaders["Authorization"] {
+		t.Fatalf("already encrypted specialist row was modified by backfill")
+	}
+
+	if _, err := pool.Exec(ctx, `
+INSERT INTO specialists(user_id, name, api_key, extra_headers)
+VALUES($1, $2, $3, $4)`, 7, "legacy", "legacy-specialist-key", []byte(`{"Authorization":"Bearer legacy-header"}`)); err != nil {
+		t.Fatalf("insert legacy specialist row: %v", err)
+	}
+	legacyStore := NewSpecialistsStoreWithCodec(pool, codec)
+	if err := legacyStore.Init(ctx); err != nil {
+		t.Fatalf("backfill legacy specialist: %v", err)
+	}
+	legacyAPIKey, legacyHeaders := rawPostgresSpecialistSecrets(t, pool, 7, "legacy")
+	assertSealedValue(t, codec, legacyAPIKey, "legacy-specialist-key")
+	assertSealedValue(t, codec, legacyHeaders["Authorization"], "legacy-header")
+}
+
+func TestPostgresMCPStoreEncryptsAndBackfillsSecrets(t *testing.T) {
+	t.Parallel()
+
+	dsn := testPostgresDSN()
+	if dsn == "" {
+		t.Skip("set MANIFOLD_TEST_POSTGRES_DSN or POSTGRES_TEST_DSN to run Postgres MCP encryption tests")
+	}
+	ctx := context.Background()
+	pool := openTestPostgresSchema(t, dsn)
+	codec := testDatabaseSecretsCodec(t)
+	store := NewMCPStoreWithCodec(pool, codec)
+	if err := store.Init(ctx); err != nil {
+		t.Fatalf("init store: %v", err)
+	}
+
+	if _, err := store.Upsert(ctx, 7, persistence.MCPServer{
+		Name:              "remote",
+		URL:               "https://mcp.example.test",
+		Headers:           map[string]string{"Authorization": "Bearer mcp-header"},
+		BearerToken:       "bearer-secret",
+		OAuthProvider:     "custom",
+		OAuthClientID:     "public-client-id",
+		OAuthClientSecret: "client-secret",
+		OAuthAccessToken:  "access-token",
+		OAuthRefreshToken: "refresh-token",
+		OAuthExpiresAt:    time.Now().UTC().Add(time.Hour),
+		OAuthScopes:       []string{"tools.read"},
+		Env:               map[string]string{"OPENAI_API_KEY": "env-secret", "PATH": "/usr/bin"},
+	}); err != nil {
+		t.Fatalf("upsert mcp: %v", err)
+	}
+	raw := rawPostgresMCPSecrets(t, pool, 7, "remote")
+	assertSealedValue(t, codec, raw.bearerToken, "bearer-secret")
+	assertSealedValue(t, codec, raw.oauthClientSecret, "client-secret")
+	assertSealedValue(t, codec, raw.oauthAccessToken, "access-token")
+	assertSealedValue(t, codec, raw.oauthRefreshToken, "refresh-token")
+	assertSealedValue(t, codec, raw.headers["Authorization"], "mcp-header")
+	assertSealedValue(t, codec, raw.env["OPENAI_API_KEY"], "env-secret")
+	if raw.env["PATH"] != "/usr/bin" {
+		t.Fatalf("expected non-secret env key to remain plaintext, got %q", raw.env["PATH"])
+	}
+
+	got, ok, err := store.GetByName(ctx, 7, "remote")
+	if err != nil {
+		t.Fatalf("get mcp: %v", err)
+	}
+	if !ok || got.BearerToken != "bearer-secret" || got.OAuthClientSecret != "client-secret" || got.OAuthAccessToken != "access-token" || got.OAuthRefreshToken != "refresh-token" {
+		t.Fatalf("unexpected decrypted mcp server: ok=%v got=%+v", ok, got)
+	}
+
+	if err := store.Init(ctx); err != nil {
+		t.Fatalf("re-init store: %v", err)
+	}
+	after := rawPostgresMCPSecrets(t, pool, 7, "remote")
+	if after.bearerToken != raw.bearerToken || after.headers["Authorization"] != raw.headers["Authorization"] || after.env["OPENAI_API_KEY"] != raw.env["OPENAI_API_KEY"] {
+		t.Fatalf("already encrypted mcp row was modified by backfill")
+	}
+
+	if _, err := pool.Exec(ctx, `
+INSERT INTO mcp_servers(user_id, name, url, headers, env, bearer_token, oauth_client_secret, oauth_access_token, oauth_refresh_token)
+VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9)`, 7, "legacy", "https://legacy.example.test", []byte(`{"Authorization":"Bearer legacy-header"}`), []byte(`{"OPENAI_API_KEY":"legacy-env","PATH":"/bin"}`), "legacy-bearer", "legacy-client", "legacy-access", "legacy-refresh"); err != nil {
+		t.Fatalf("insert legacy mcp row: %v", err)
+	}
+	legacyStore := NewMCPStoreWithCodec(pool, codec)
+	if err := legacyStore.Init(ctx); err != nil {
+		t.Fatalf("backfill legacy mcp: %v", err)
+	}
+	legacyRaw := rawPostgresMCPSecrets(t, pool, 7, "legacy")
+	assertSealedValue(t, codec, legacyRaw.bearerToken, "legacy-bearer")
+	assertSealedValue(t, codec, legacyRaw.oauthClientSecret, "legacy-client")
+	assertSealedValue(t, codec, legacyRaw.oauthAccessToken, "legacy-access")
+	assertSealedValue(t, codec, legacyRaw.oauthRefreshToken, "legacy-refresh")
+	assertSealedValue(t, codec, legacyRaw.headers["Authorization"], "legacy-header")
+	assertSealedValue(t, codec, legacyRaw.env["OPENAI_API_KEY"], "legacy-env")
+}
+
+func TestManagerSQLiteSecretsKeyRequired(t *testing.T) {
+	ctx := context.Background()
+	t.Setenv(secrets.EnvKeyName, "")
+
+	_, err := NewManager(ctx, config.DBConfig{
+		SQLite: config.SQLiteConfig{Path: filepath.Join(t.TempDir(), "manifold.db")},
+	})
+	if err == nil || !strings.Contains(err.Error(), secrets.EnvKeyName) {
+		t.Fatalf("expected missing secrets key error, got %v", err)
+	}
+}
+
+func TestManagerSQLiteSecretsKeyRejectsInvalidFormat(t *testing.T) {
+	ctx := context.Background()
+	t.Setenv(secrets.EnvKeyName, "not-base64")
+
+	_, err := NewManager(ctx, config.DBConfig{
+		SQLite: config.SQLiteConfig{Path: filepath.Join(t.TempDir(), "manifold.db")},
+	})
+	if err == nil || !strings.Contains(err.Error(), "base64-encoded 32 raw bytes") {
+		t.Fatalf("expected invalid secrets key error, got %v", err)
+	}
+}
+
+func TestManagerMemoryBackendsDoNotRequireSecretsKey(t *testing.T) {
+	ctx := context.Background()
+	t.Setenv(secrets.EnvKeyName, "")
+
+	mgr, err := NewManager(ctx, config.DBConfig{
+		Backend: "memory",
+		Search:  config.SearchConfig{Backend: "none"},
+		Vector:  config.VectorConfig{Backend: "none"},
+		Graph:   config.GraphConfig{Backend: "none"},
+		Chat:    config.ChatConfig{Backend: "memory"},
+	})
+	if err != nil {
+		t.Fatalf("NewManager memory backends: %v", err)
+	}
+	defer mgr.Close()
+}
+
+func rawSQLiteSpecialistSecrets(t *testing.T, db *sql.DB, userID int64, name string) (string, map[string]string) {
+	t.Helper()
+	var rawAPIKey string
+	var rawHeaders []byte
+	if err := db.QueryRow(`SELECT api_key, extra_headers FROM specialists WHERE user_id = ? AND name = ?`, userID, name).Scan(&rawAPIKey, &rawHeaders); err != nil {
+		t.Fatalf("query raw specialist row: %v", err)
+	}
+	return rawAPIKey, decodeSecretStringMap(t, rawHeaders)
+}
+
+func rawPostgresSpecialistSecrets(t *testing.T, pool *pgxpool.Pool, userID int64, name string) (string, map[string]string) {
+	t.Helper()
+	var rawAPIKey string
+	var rawHeaders []byte
+	if err := pool.QueryRow(context.Background(), `SELECT api_key, extra_headers FROM specialists WHERE user_id = $1 AND name = $2`, userID, name).Scan(&rawAPIKey, &rawHeaders); err != nil {
+		t.Fatalf("query raw specialist row: %v", err)
+	}
+	return rawAPIKey, decodeSecretStringMap(t, rawHeaders)
+}
+
+type rawMCPSecrets struct {
+	env               map[string]string
+	headers           map[string]string
+	bearerToken       string
+	oauthClientSecret string
+	oauthAccessToken  string
+	oauthRefreshToken string
+}
+
+func rawSQLiteMCPSecrets(t *testing.T, db *sql.DB, userID int64, name string) rawMCPSecrets {
+	t.Helper()
+	var raw rawMCPSecrets
+	var env, headers []byte
+	if err := db.QueryRow(`
+SELECT env, headers, bearer_token, oauth_client_secret, oauth_access_token, oauth_refresh_token
+FROM mcp_servers WHERE user_id = ? AND name = ?`, userID, name).Scan(&env, &headers, &raw.bearerToken, &raw.oauthClientSecret, &raw.oauthAccessToken, &raw.oauthRefreshToken); err != nil {
+		t.Fatalf("query raw mcp row: %v", err)
+	}
+	raw.env = decodeSecretStringMap(t, env)
+	raw.headers = decodeSecretStringMap(t, headers)
+	return raw
+}
+
+func rawPostgresMCPSecrets(t *testing.T, pool *pgxpool.Pool, userID int64, name string) rawMCPSecrets {
+	t.Helper()
+	var raw rawMCPSecrets
+	var env, headers []byte
+	if err := pool.QueryRow(context.Background(), `
+SELECT env, headers, bearer_token, oauth_client_secret, oauth_access_token, oauth_refresh_token
+FROM mcp_servers WHERE user_id = $1 AND name = $2`, userID, name).Scan(&env, &headers, &raw.bearerToken, &raw.oauthClientSecret, &raw.oauthAccessToken, &raw.oauthRefreshToken); err != nil {
+		t.Fatalf("query raw mcp row: %v", err)
+	}
+	raw.env = decodeSecretStringMap(t, env)
+	raw.headers = decodeSecretStringMap(t, headers)
+	return raw
+}
+
+func decodeSecretStringMap(t *testing.T, data []byte) map[string]string {
+	t.Helper()
+	out := map[string]string{}
+	if len(data) == 0 {
+		return out
+	}
+	if err := json.Unmarshal(data, &out); err != nil {
+		t.Fatalf("decode string map %s: %v", string(data), err)
+	}
+	return out
+}
+
+func assertSealedValue(t *testing.T, codec secrets.Codec, value, plaintextFragment string) {
+	t.Helper()
+	if !codec.IsSealed(value) {
+		t.Fatalf("expected sealed value, got %q", value)
+	}
+	if strings.Contains(value, plaintextFragment) {
+		t.Fatalf("sealed value contains plaintext fragment %q: %q", plaintextFragment, value)
+	}
+}

--- a/internal/persistence/databases/specialists_store.go
+++ b/internal/persistence/databases/specialists_store.go
@@ -5,10 +5,12 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 	"sync"
 
 	"manifold/internal/persistence"
+	"manifold/internal/secrets"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 )
@@ -21,8 +23,16 @@ func NewSpecialistsStore(pool *pgxpool.Pool) persistence.SpecialistsStore {
 	return &pgSpecStore{pool: pool}
 }
 
+func NewSpecialistsStoreWithCodec(pool *pgxpool.Pool, codec secrets.Codec) persistence.SpecialistsStore {
+	if pool == nil {
+		return &memSpecStore{m: map[int64]map[string]persistence.Specialist{}}
+	}
+	return &pgSpecStore{pool: pool, codec: codec}
+}
+
 type sqliteSpecStore struct {
 	db       *sql.DB
+	codec    secrets.Codec
 	initOnce sync.Once
 	initErr  error
 }
@@ -31,15 +41,32 @@ func NewSQLiteSpecialistsStore(db *sql.DB) persistence.SpecialistsStore {
 	return &sqliteSpecStore{db: db}
 }
 
+func NewSQLiteSpecialistsStoreWithCodec(db *sql.DB, codec secrets.Codec) persistence.SpecialistsStore {
+	return &sqliteSpecStore{db: db, codec: codec}
+}
+
+func (s *sqliteSpecStore) ensureCodec() (secrets.Codec, error) {
+	codec, err := databaseSecretCodec(s.codec)
+	if err != nil {
+		return nil, err
+	}
+	s.codec = codec
+	return codec, nil
+}
+
 func (s *sqliteSpecStore) Init(ctx context.Context) error {
 	if s.db == nil {
 		return errors.New("sqlite specialists store requires db")
 	}
+	codec, err := s.ensureCodec()
+	if err != nil {
+		return err
+	}
 	s.initOnce.Do(func() {
-		_, s.initErr = s.db.ExecContext(ctx, `
-CREATE TABLE IF NOT EXISTS specialists (
-	id INTEGER PRIMARY KEY AUTOINCREMENT,
-	user_id INTEGER NOT NULL DEFAULT 0,
+		if _, err := s.db.ExecContext(ctx, `
+	CREATE TABLE IF NOT EXISTS specialists (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		user_id INTEGER NOT NULL DEFAULT 0,
 	name TEXT NOT NULL,
 	description TEXT NOT NULL DEFAULT '',
 	base_url TEXT NOT NULL DEFAULT '',
@@ -59,9 +86,13 @@ CREATE TABLE IF NOT EXISTS specialists (
 	harness TEXT DEFAULT NULL,
 	provider TEXT NOT NULL DEFAULT '',
 	UNIQUE(user_id, name)
-);
-CREATE INDEX IF NOT EXISTS specialists_user_name_idx ON specialists(user_id, name);
-`)
+	);
+	CREATE INDEX IF NOT EXISTS specialists_user_name_idx ON specialists(user_id, name);
+	`); err != nil {
+			s.initErr = err
+			return
+		}
+		s.initErr = backfillSQLiteSpecialistSecrets(ctx, s.db, codec)
 	})
 	return s.initErr
 }
@@ -78,6 +109,10 @@ func (s *sqliteSpecStore) List(ctx context.Context, userID int64) ([]persistence
 	out := []persistence.Specialist{}
 	for rows.Next() {
 		sp, err := scanSQLiteSpecialist(rows)
+		if err != nil {
+			return nil, err
+		}
+		sp, err = decryptSpecialistFromStore(s.codec, sp)
 		if err != nil {
 			return nil, err
 		}
@@ -98,6 +133,10 @@ func (s *sqliteSpecStore) GetByName(ctx context.Context, userID int64, name stri
 	if err != nil {
 		return persistence.Specialist{}, false, err
 	}
+	sp, err = decryptSpecialistFromStore(s.codec, sp)
+	if err != nil {
+		return persistence.Specialist{}, false, err
+	}
 	return sp, true, nil
 }
 
@@ -108,8 +147,12 @@ func (s *sqliteSpecStore) Upsert(ctx context.Context, userID int64, sp persisten
 	if err := s.Init(ctx); err != nil {
 		return persistence.Specialist{}, err
 	}
+	toStore, err := encryptSpecialistForStore(s.codec, userID, sp)
+	if err != nil {
+		return persistence.Specialist{}, err
+	}
 	allow, _ := json.Marshal(sp.AllowTools)
-	headers, _ := json.Marshal(sp.ExtraHeaders)
+	headers, _ := json.Marshal(toStore.ExtraHeaders)
 	params, _ := json.Marshal(sp.ExtraParams)
 	harness := encodeSpecialistHarness(sp.Harness)
 	row := s.db.QueryRowContext(ctx, `
@@ -133,15 +176,15 @@ ON CONFLICT(user_id, name) DO UPDATE SET
 	reasoning_effort=excluded.reasoning_effort,
 	system=excluded.system,
 	extra_headers=excluded.extra_headers,
-	extra_params=excluded.extra_params,
-	harness=excluded.harness,
-	provider=excluded.provider
-RETURNING id, api_key`, userID, sp.Name, sp.Description, sp.BaseURL, sp.APIKey, sp.Model, sp.SummaryContextWindowTokens, sp.EnableTools, nullableBool(sp.RequestInfoEnabled), sp.ImageGeneration, nullableBool(sp.AutoDiscover), sp.Paused, string(allow), sp.ReasoningEffort, sp.System, string(headers), string(params), nullableJSON(harness), sp.Provider)
+		extra_params=excluded.extra_params,
+		harness=excluded.harness,
+		provider=excluded.provider
+	RETURNING id, api_key`, userID, sp.Name, sp.Description, sp.BaseURL, toStore.APIKey, sp.Model, sp.SummaryContextWindowTokens, sp.EnableTools, nullableBool(sp.RequestInfoEnabled), sp.ImageGeneration, nullableBool(sp.AutoDiscover), sp.Paused, string(allow), sp.ReasoningEffort, sp.System, string(headers), string(params), nullableJSON(harness), sp.Provider)
 	if err := row.Scan(&sp.ID, &sp.APIKey); err != nil {
 		return persistence.Specialist{}, err
 	}
 	sp.UserID = userID
-	return sp, nil
+	return decryptSpecialistFromStore(s.codec, sp)
 }
 
 func boolPtr(value bool) *bool {
@@ -250,12 +293,18 @@ func (s *memSpecStore) Delete(ctx context.Context, userID int64, name string) er
 }
 
 type pgSpecStore struct {
-	pool *pgxpool.Pool
+	pool  *pgxpool.Pool
+	codec secrets.Codec
 }
 
 func (s *pgSpecStore) Init(ctx context.Context) error {
-	_, err := s.pool.Exec(ctx, `
-CREATE TABLE IF NOT EXISTS specialists (
+	codec, err := databaseSecretCodec(s.codec)
+	if err != nil {
+		return err
+	}
+	s.codec = codec
+	_, err = s.pool.Exec(ctx, `
+	CREATE TABLE IF NOT EXISTS specialists (
 	id SERIAL PRIMARY KEY,
 	user_id BIGINT NOT NULL DEFAULT 0,
 	name TEXT NOT NULL,
@@ -305,12 +354,20 @@ ALTER TABLE specialists
 ALTER TABLE specialists
 	DROP CONSTRAINT IF EXISTS specialists_name_key;
 
-CREATE UNIQUE INDEX IF NOT EXISTS specialists_user_name_idx ON specialists(user_id, name);
-`)
-	return err
+	CREATE UNIQUE INDEX IF NOT EXISTS specialists_user_name_idx ON specialists(user_id, name);
+	`)
+	if err != nil {
+		return err
+	}
+	return backfillPostgresSpecialistSecrets(ctx, s.pool, codec)
 }
 
 func (s *pgSpecStore) List(ctx context.Context, userID int64) ([]persistence.Specialist, error) {
+	codec, err := databaseSecretCodec(s.codec)
+	if err != nil {
+		return nil, err
+	}
+	s.codec = codec
 	rows, err := s.pool.Query(ctx, `SELECT id,user_id,name,description,base_url,api_key,model,summary_context_window_tokens,enable_tools,request_info_enabled,image_generation,auto_discover,paused,allow_tools,reasoning_effort,system,extra_headers,extra_params,harness,provider FROM specialists WHERE user_id=$1 ORDER BY LOWER(name)`, userID)
 	if err != nil {
 		return nil, err
@@ -327,12 +384,21 @@ func (s *pgSpecStore) List(ctx context.Context, userID int64) ([]persistence.Spe
 		_ = json.Unmarshal(headers, &sp.ExtraHeaders)
 		_ = json.Unmarshal(params, &sp.ExtraParams)
 		sp.Harness = decodeSpecialistHarness(harness)
+		sp, err = decryptSpecialistFromStore(codec, sp)
+		if err != nil {
+			return nil, err
+		}
 		out = append(out, sp)
 	}
 	return out, rows.Err()
 }
 
 func (s *pgSpecStore) GetByName(ctx context.Context, userID int64, name string) (persistence.Specialist, bool, error) {
+	codec, err := databaseSecretCodec(s.codec)
+	if err != nil {
+		return persistence.Specialist{}, false, err
+	}
+	s.codec = codec
 	row := s.pool.QueryRow(ctx, `SELECT id,user_id,name,description,base_url,api_key,model,summary_context_window_tokens,enable_tools,request_info_enabled,image_generation,auto_discover,paused,allow_tools,reasoning_effort,system,extra_headers,extra_params,harness,provider FROM specialists WHERE user_id=$1 AND name=$2`, userID, name)
 	var sp persistence.Specialist
 	var allow, headers, params, harness []byte
@@ -343,6 +409,10 @@ func (s *pgSpecStore) GetByName(ctx context.Context, userID int64, name string) 
 	_ = json.Unmarshal(headers, &sp.ExtraHeaders)
 	_ = json.Unmarshal(params, &sp.ExtraParams)
 	sp.Harness = decodeSpecialistHarness(harness)
+	sp, err = decryptSpecialistFromStore(codec, sp)
+	if err != nil {
+		return persistence.Specialist{}, false, err
+	}
 	return sp, true, nil
 }
 
@@ -350,27 +420,36 @@ func (s *pgSpecStore) Upsert(ctx context.Context, userID int64, sp persistence.S
 	if strings.TrimSpace(sp.Name) == "" {
 		return persistence.Specialist{}, errors.New("name required")
 	}
+	codec, err := databaseSecretCodec(s.codec)
+	if err != nil {
+		return persistence.Specialist{}, err
+	}
+	s.codec = codec
+	toStore, err := encryptSpecialistForStore(s.codec, userID, sp)
+	if err != nil {
+		return persistence.Specialist{}, err
+	}
 	allow, _ := json.Marshal(sp.AllowTools)
-	headers, _ := json.Marshal(sp.ExtraHeaders)
+	headers, _ := json.Marshal(toStore.ExtraHeaders)
 	params, _ := json.Marshal(sp.ExtraParams)
 	harness := encodeSpecialistHarness(sp.Harness)
 	row := s.pool.QueryRow(ctx, `
 INSERT INTO specialists(user_id,name,description,base_url,api_key,model,summary_context_window_tokens,enable_tools,request_info_enabled,image_generation,auto_discover,paused,allow_tools,reasoning_effort,system,extra_headers,extra_params,harness,provider)
 VALUES($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19)
-	ON CONFLICT (user_id, name) DO UPDATE SET description=EXCLUDED.description, base_url=EXCLUDED.base_url,
+		ON CONFLICT (user_id, name) DO UPDATE SET description=EXCLUDED.description, base_url=EXCLUDED.base_url,
 		api_key=CASE
 			WHEN NULLIF(BTRIM(EXCLUDED.api_key), '') IS NULL THEN specialists.api_key
 			ELSE EXCLUDED.api_key
 		END,
 		model=EXCLUDED.model,
-	summary_context_window_tokens=EXCLUDED.summary_context_window_tokens, enable_tools=EXCLUDED.enable_tools, request_info_enabled=EXCLUDED.request_info_enabled, image_generation=EXCLUDED.image_generation, auto_discover=EXCLUDED.auto_discover, paused=EXCLUDED.paused, allow_tools=EXCLUDED.allow_tools,
-	reasoning_effort=EXCLUDED.reasoning_effort, system=EXCLUDED.system, extra_headers=EXCLUDED.extra_headers, extra_params=EXCLUDED.extra_params, harness=EXCLUDED.harness, provider=EXCLUDED.provider
-RETURNING id;`, userID, sp.Name, sp.Description, sp.BaseURL, sp.APIKey, sp.Model, sp.SummaryContextWindowTokens, sp.EnableTools, sp.RequestInfoEnabled, sp.ImageGeneration, sp.AutoDiscover, sp.Paused, allow, sp.ReasoningEffort, sp.System, headers, params, harness, sp.Provider)
-	if err := row.Scan(&sp.ID); err != nil {
+		summary_context_window_tokens=EXCLUDED.summary_context_window_tokens, enable_tools=EXCLUDED.enable_tools, request_info_enabled=EXCLUDED.request_info_enabled, image_generation=EXCLUDED.image_generation, auto_discover=EXCLUDED.auto_discover, paused=EXCLUDED.paused, allow_tools=EXCLUDED.allow_tools,
+		reasoning_effort=EXCLUDED.reasoning_effort, system=EXCLUDED.system, extra_headers=EXCLUDED.extra_headers, extra_params=EXCLUDED.extra_params, harness=EXCLUDED.harness, provider=EXCLUDED.provider
+	RETURNING id, api_key;`, userID, sp.Name, sp.Description, sp.BaseURL, toStore.APIKey, sp.Model, sp.SummaryContextWindowTokens, sp.EnableTools, sp.RequestInfoEnabled, sp.ImageGeneration, sp.AutoDiscover, sp.Paused, allow, sp.ReasoningEffort, sp.System, headers, params, harness, sp.Provider)
+	if err := row.Scan(&sp.ID, &sp.APIKey); err != nil {
 		return persistence.Specialist{}, err
 	}
 	sp.UserID = userID
-	return sp, nil
+	return decryptSpecialistFromStore(s.codec, sp)
 }
 
 func decodeSpecialistHarness(data []byte) *persistence.SpecialistHarness {
@@ -398,4 +477,122 @@ func encodeSpecialistHarness(cfg *persistence.SpecialistHarness) []byte {
 func (s *pgSpecStore) Delete(ctx context.Context, userID int64, name string) error {
 	_, err := s.pool.Exec(ctx, `DELETE FROM specialists WHERE user_id=$1 AND name=$2`, userID, name)
 	return err
+}
+
+type specialistSecretRecord struct {
+	ID           int64
+	UserID       int64
+	Name         string
+	APIKey       string
+	ExtraHeaders map[string]string
+}
+
+func backfillSQLiteSpecialistSecrets(ctx context.Context, db *sql.DB, codec secrets.Codec) error {
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	rows, err := tx.QueryContext(ctx, `SELECT id, user_id, name, api_key, extra_headers FROM specialists`)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = rows.Close() }()
+	records, err := scanSpecialistSecretRecords(rows)
+	if err != nil {
+		return err
+	}
+
+	for _, record := range records {
+		if !specialistRecordNeedsBackfill(codec, record) {
+			continue
+		}
+		encrypted, err := encryptSpecialistForStore(codec, record.UserID, persistence.Specialist{
+			UserID:       record.UserID,
+			Name:         record.Name,
+			APIKey:       record.APIKey,
+			ExtraHeaders: record.ExtraHeaders,
+		})
+		if err != nil {
+			return fmt.Errorf("backfill specialist secrets id=%d: %w", record.ID, err)
+		}
+		headers, _ := json.Marshal(encrypted.ExtraHeaders)
+		if _, err := tx.ExecContext(ctx, `UPDATE specialists SET api_key = ?, extra_headers = ? WHERE id = ?`, encrypted.APIKey, string(headers), record.ID); err != nil {
+			return fmt.Errorf("update specialist secret backfill id=%d: %w", record.ID, err)
+		}
+	}
+	return tx.Commit()
+}
+
+func backfillPostgresSpecialistSecrets(ctx context.Context, pool *pgxpool.Pool, codec secrets.Codec) error {
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	rows, err := tx.Query(ctx, `SELECT id, user_id, name, api_key, extra_headers FROM specialists`)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+	records, err := scanSpecialistSecretRecords(rows)
+	if err != nil {
+		return err
+	}
+
+	for _, record := range records {
+		if !specialistRecordNeedsBackfill(codec, record) {
+			continue
+		}
+		encrypted, err := encryptSpecialistForStore(codec, record.UserID, persistence.Specialist{
+			UserID:       record.UserID,
+			Name:         record.Name,
+			APIKey:       record.APIKey,
+			ExtraHeaders: record.ExtraHeaders,
+		})
+		if err != nil {
+			return fmt.Errorf("backfill specialist secrets id=%d: %w", record.ID, err)
+		}
+		headers, _ := json.Marshal(encrypted.ExtraHeaders)
+		if _, err := tx.Exec(ctx, `UPDATE specialists SET api_key = $1, extra_headers = $2 WHERE id = $3`, encrypted.APIKey, headers, record.ID); err != nil {
+			return fmt.Errorf("update specialist secret backfill id=%d: %w", record.ID, err)
+		}
+	}
+	return tx.Commit(ctx)
+}
+
+func scanSpecialistSecretRecords(rows interface {
+	Next() bool
+	Scan(dest ...any) error
+	Err() error
+}) ([]specialistSecretRecord, error) {
+	var records []specialistSecretRecord
+	for rows.Next() {
+		var record specialistSecretRecord
+		var headers []byte
+		if err := rows.Scan(&record.ID, &record.UserID, &record.Name, &record.APIKey, &headers); err != nil {
+			return nil, err
+		}
+		if len(headers) > 0 {
+			if err := json.Unmarshal(headers, &record.ExtraHeaders); err != nil {
+				return nil, fmt.Errorf("specialist extra_headers id=%d: %w", record.ID, err)
+			}
+		}
+		records = append(records, record)
+	}
+	return records, rows.Err()
+}
+
+func specialistRecordNeedsBackfill(codec secrets.Codec, record specialistSecretRecord) bool {
+	if record.APIKey != "" && !codec.IsSealed(record.APIKey) {
+		return true
+	}
+	for _, value := range record.ExtraHeaders {
+		if value != "" && !codec.IsSealed(value) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/persistence/databases/sqlite_default_stores.go
+++ b/internal/persistence/databases/sqlite_default_stores.go
@@ -12,6 +12,7 @@ import (
 
 	"manifold/internal/config"
 	persist "manifold/internal/persistence"
+	"manifold/internal/secrets"
 	"manifold/internal/transit"
 )
 
@@ -358,19 +359,37 @@ func scanSQLiteFlowV2WorkflowRecord(row interface{ Scan(dest ...any) error }, us
 }
 
 type sqliteMCPStore struct {
-	db *sql.DB
+	db    *sql.DB
+	codec secrets.Codec
 }
 
 func NewSQLiteMCPStore(db *sql.DB) persist.MCPStore {
 	return &sqliteMCPStore{db: db}
 }
 
+func NewSQLiteMCPStoreWithCodec(db *sql.DB, codec secrets.Codec) persist.MCPStore {
+	return &sqliteMCPStore{db: db, codec: codec}
+}
+
+func (s *sqliteMCPStore) ensureCodec() (secrets.Codec, error) {
+	codec, err := databaseSecretCodec(s.codec)
+	if err != nil {
+		return nil, err
+	}
+	s.codec = codec
+	return codec, nil
+}
+
 func (s *sqliteMCPStore) Init(ctx context.Context) error {
 	if s.db == nil {
 		return errors.New("sqlite mcp store requires db")
 	}
-	_, err := s.db.ExecContext(ctx, `
-CREATE TABLE IF NOT EXISTS mcp_servers (
+	codec, err := s.ensureCodec()
+	if err != nil {
+		return err
+	}
+	_, err = s.db.ExecContext(ctx, `
+	CREATE TABLE IF NOT EXISTS mcp_servers (
 	id INTEGER PRIMARY KEY AUTOINCREMENT,
 	user_id INTEGER NOT NULL DEFAULT 0,
 	name TEXT NOT NULL,
@@ -392,9 +411,12 @@ CREATE TABLE IF NOT EXISTS mcp_servers (
 	oauth_expires_at DATETIME,
 	oauth_scopes TEXT NOT NULL DEFAULT '[]' CHECK (json_valid(oauth_scopes)),
 	UNIQUE(user_id, name)
-);
-`)
-	return err
+	);
+	`)
+	if err != nil {
+		return err
+	}
+	return backfillSQLiteMCPSecrets(ctx, s.db, codec)
 }
 
 func (s *sqliteMCPStore) List(ctx context.Context, userID int64) ([]persist.MCPServer, error) {
@@ -414,6 +436,10 @@ ORDER BY name ASC`, userID)
 	out := []persist.MCPServer{}
 	for rows.Next() {
 		srv, err := scanSQLiteMCPServer(rows)
+		if err != nil {
+			return nil, err
+		}
+		srv, err = decryptMCPServerFromStore(s.codec, srv)
 		if err != nil {
 			return nil, err
 		}
@@ -438,6 +464,10 @@ WHERE user_id = ? AND name = ?`, userID, name)
 	if err != nil {
 		return persist.MCPServer{}, false, err
 	}
+	srv, err = decryptMCPServerFromStore(s.codec, srv)
+	if err != nil {
+		return persist.MCPServer{}, false, err
+	}
 	return srv, true, nil
 }
 
@@ -446,6 +476,10 @@ func (s *sqliteMCPStore) Upsert(ctx context.Context, userID int64, srv persist.M
 		return persist.MCPServer{}, errors.New("name required")
 	}
 	if err := s.Init(ctx); err != nil {
+		return persist.MCPServer{}, err
+	}
+	toStore, err := encryptMCPServerForStore(s.codec, userID, srv)
+	if err != nil {
 		return persist.MCPServer{}, err
 	}
 	var expiresAt any
@@ -473,11 +507,11 @@ ON CONFLICT(user_id, name) DO UPDATE SET
 	oauth_access_token = excluded.oauth_access_token,
 	oauth_refresh_token = excluded.oauth_refresh_token,
 	oauth_expires_at = excluded.oauth_expires_at,
-	oauth_scopes = excluded.oauth_scopes
-RETURNING id
-`, userID, srv.Name, srv.Command, encodeJSON(srv.Args, "[]"), encodeJSON(srv.Env, "{}"), srv.URL, encodeJSON(srv.Headers, "{}"),
-		srv.BearerToken, srv.Origin, srv.ProtocolVersion, srv.KeepAliveSeconds, srv.Disabled, srv.OAuthProvider, srv.OAuthClientID, srv.OAuthClientSecret,
-		srv.OAuthAccessToken, srv.OAuthRefreshToken, expiresAt, encodeJSON(srv.OAuthScopes, "[]"))
+		oauth_scopes = excluded.oauth_scopes
+	RETURNING id
+	`, userID, srv.Name, srv.Command, encodeJSON(srv.Args, "[]"), encodeJSON(toStore.Env, "{}"), srv.URL, encodeJSON(toStore.Headers, "{}"),
+		toStore.BearerToken, srv.Origin, srv.ProtocolVersion, srv.KeepAliveSeconds, srv.Disabled, srv.OAuthProvider, srv.OAuthClientID, toStore.OAuthClientSecret,
+		toStore.OAuthAccessToken, toStore.OAuthRefreshToken, expiresAt, encodeJSON(srv.OAuthScopes, "[]"))
 	if err := row.Scan(&srv.ID); err != nil {
 		return persist.MCPServer{}, err
 	}

--- a/internal/persistence/store.go
+++ b/internal/persistence/store.go
@@ -271,6 +271,7 @@ type ChatSession struct {
 	CreatedAt             time.Time `json:"createdAt"`
 	UpdatedAt             time.Time `json:"updatedAt"`
 	LastMessagePreview    string    `json:"lastMessagePreview"`
+	MessageCount          int       `json:"messageCount"`
 	Model                 string    `json:"model"`
 	Summary               string    `json:"summary"`
 	SummarizedCount       int       `json:"summarizedCount"`
@@ -283,11 +284,12 @@ type ChatSession struct {
 
 // ChatMessage is a single turn within a chat session.
 type ChatMessage struct {
-	ID        string    `json:"id"`
-	SessionID string    `json:"sessionId"`
-	Role      string    `json:"role"`
-	Content   string    `json:"content"`
-	CreatedAt time.Time `json:"createdAt"`
+	ID         string    `json:"id"`
+	SessionID  string    `json:"sessionId"`
+	Role       string    `json:"role"`
+	Content    string    `json:"content"`
+	CreatedAt  time.Time `json:"createdAt"`
+	DurationMs *int64    `json:"durationMs,omitempty"`
 	// Optional, not persisted: used to hydrate tool calls for the UI.
 	Title    string `json:"title,omitempty"`
 	ToolArgs string `json:"toolArgs,omitempty"`

--- a/internal/rag/service/service.go
+++ b/internal/rag/service/service.go
@@ -475,7 +475,9 @@ func magmaServiceConfig(cfg config.MagmaConfig, observer magma.Observer, provide
 			MinSemanticWeight:      cfg.Lifecycle.MinSemanticWeight,
 			LowConfidenceThreshold: cfg.Lifecycle.LowConfidenceThreshold,
 			RequireReviewApproval:  cfg.Lifecycle.RequireReviewApproval,
+			ArchiveBeforeDelete:    cfg.Lifecycle.ArchiveBeforeDelete,
 		},
+		RequireCausalGrounding: cfg.Lifecycle.RequireCausalGrounding,
 		Graphs: magma.GraphConfig{
 			Semantic:    cfg.Graphs.Semantic.Enabled,
 			Temporal:    cfg.Graphs.Temporal.Enabled,

--- a/internal/secrets/codec.go
+++ b/internal/secrets/codec.go
@@ -1,0 +1,114 @@
+package secrets
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"golang.org/x/crypto/chacha20poly1305"
+)
+
+const (
+	EnvKeyName = "MANIFOLD_SECRETS_KEY"
+
+	envelopePrefix = "mfdsec:v1:xchacha20poly1305:"
+	keySize        = chacha20poly1305.KeySize
+)
+
+// Codec encrypts and decrypts persisted secret strings.
+type Codec interface {
+	SealString(plaintext, aad string) (string, error)
+	OpenString(value, aad string) (string, error)
+	IsSealed(value string) bool
+}
+
+type xchachaCodec struct {
+	key [keySize]byte
+}
+
+// NewCodec creates a secret codec from 32 raw key bytes.
+func NewCodec(key []byte) (Codec, error) {
+	if len(key) != keySize {
+		return nil, fmt.Errorf("secrets key must be %d bytes, got %d", keySize, len(key))
+	}
+	c := &xchachaCodec{}
+	copy(c.key[:], key)
+	return c, nil
+}
+
+// NewCodecFromEnv creates a codec from MANIFOLD_SECRETS_KEY.
+func NewCodecFromEnv() (Codec, error) {
+	value := strings.TrimSpace(os.Getenv(EnvKeyName))
+	if value == "" {
+		return nil, fmt.Errorf("%s is required for database-backed secret storage; generate one with: openssl rand -base64 32", EnvKeyName)
+	}
+	key, err := base64.StdEncoding.DecodeString(value)
+	if err != nil {
+		key, err = base64.RawStdEncoding.DecodeString(value)
+	}
+	if err != nil {
+		key, err = base64.RawURLEncoding.DecodeString(value)
+	}
+	if err != nil {
+		key, err = base64.URLEncoding.DecodeString(value)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("%s must be base64-encoded 32 raw bytes: %w", EnvKeyName, err)
+	}
+	codec, err := NewCodec(key)
+	if err != nil {
+		return nil, fmt.Errorf("%s must be base64-encoded 32 raw bytes: %w", EnvKeyName, err)
+	}
+	return codec, nil
+}
+
+func (c *xchachaCodec) SealString(plaintext, aad string) (string, error) {
+	if plaintext == "" || c.IsSealed(plaintext) {
+		return plaintext, nil
+	}
+	aead, err := chacha20poly1305.NewX(c.key[:])
+	if err != nil {
+		return "", fmt.Errorf("initialize secret cipher: %w", err)
+	}
+	nonce := make([]byte, chacha20poly1305.NonceSizeX)
+	if _, err := rand.Read(nonce); err != nil {
+		return "", fmt.Errorf("generate secret nonce: %w", err)
+	}
+	sealed := aead.Seal(nonce, nonce, []byte(plaintext), []byte(aad))
+	return envelopePrefix + base64.RawURLEncoding.EncodeToString(sealed), nil
+}
+
+func (c *xchachaCodec) OpenString(value, aad string) (string, error) {
+	if value == "" {
+		return "", nil
+	}
+	if !c.IsSealed(value) {
+		return value, nil
+	}
+	encoded := strings.TrimPrefix(value, envelopePrefix)
+	payload, err := base64.RawURLEncoding.DecodeString(encoded)
+	if err != nil {
+		return "", fmt.Errorf("decode secret envelope: %w", err)
+	}
+	if len(payload) < chacha20poly1305.NonceSizeX {
+		return "", errors.New("secret envelope payload is too short")
+	}
+	aead, err := chacha20poly1305.NewX(c.key[:])
+	if err != nil {
+		return "", fmt.Errorf("initialize secret cipher: %w", err)
+	}
+	nonce := payload[:chacha20poly1305.NonceSizeX]
+	ciphertext := payload[chacha20poly1305.NonceSizeX:]
+	plaintext, err := aead.Open(nil, nonce, ciphertext, []byte(aad))
+	if err != nil {
+		return "", fmt.Errorf("open secret envelope: %w", err)
+	}
+	return string(plaintext), nil
+}
+
+func (c *xchachaCodec) IsSealed(value string) bool {
+	return strings.HasPrefix(value, envelopePrefix)
+}

--- a/internal/secrets/codec_test.go
+++ b/internal/secrets/codec_test.go
@@ -1,0 +1,121 @@
+package secrets
+
+import (
+	"encoding/base64"
+	"strings"
+	"testing"
+)
+
+func testCodec(t *testing.T) Codec {
+	t.Helper()
+	key := make([]byte, keySize)
+	for i := range key {
+		key[i] = byte(i + 1)
+	}
+	codec, err := NewCodec(key)
+	if err != nil {
+		t.Fatalf("NewCodec: %v", err)
+	}
+	return codec
+}
+
+func TestCodecRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	codec := testCodec(t)
+	sealed, err := codec.SealString("secret-value", "row/a")
+	if err != nil {
+		t.Fatalf("SealString: %v", err)
+	}
+	if !codec.IsSealed(sealed) {
+		t.Fatalf("expected sealed envelope, got %q", sealed)
+	}
+	got, err := codec.OpenString(sealed, "row/a")
+	if err != nil {
+		t.Fatalf("OpenString: %v", err)
+	}
+	if got != "secret-value" {
+		t.Fatalf("got %q, want secret-value", got)
+	}
+}
+
+func TestCodecUsesRandomNonce(t *testing.T) {
+	t.Parallel()
+
+	codec := testCodec(t)
+	first, err := codec.SealString("same", "row/a")
+	if err != nil {
+		t.Fatalf("SealString first: %v", err)
+	}
+	second, err := codec.SealString("same", "row/a")
+	if err != nil {
+		t.Fatalf("SealString second: %v", err)
+	}
+	if first == second {
+		t.Fatalf("expected different ciphertexts for same plaintext")
+	}
+}
+
+func TestCodecAADMismatchFails(t *testing.T) {
+	t.Parallel()
+
+	codec := testCodec(t)
+	sealed, err := codec.SealString("secret-value", "row/a")
+	if err != nil {
+		t.Fatalf("SealString: %v", err)
+	}
+	if _, err := codec.OpenString(sealed, "row/b"); err == nil {
+		t.Fatalf("expected AAD mismatch to fail")
+	}
+}
+
+func TestCodecHandlesEmptyAndPlaintext(t *testing.T) {
+	t.Parallel()
+
+	codec := testCodec(t)
+	if got, err := codec.SealString("", "row/a"); err != nil || got != "" {
+		t.Fatalf("SealString empty = %q, %v", got, err)
+	}
+	if got, err := codec.OpenString("plain", "row/a"); err != nil || got != "plain" {
+		t.Fatalf("OpenString plaintext = %q, %v", got, err)
+	}
+}
+
+func TestCodecMalformedEnvelopeFails(t *testing.T) {
+	t.Parallel()
+
+	codec := testCodec(t)
+	if _, err := codec.OpenString(envelopePrefix+"not-base64-!", "row/a"); err == nil {
+		t.Fatalf("expected malformed base64 to fail")
+	}
+	shortPayload := envelopePrefix + base64.RawURLEncoding.EncodeToString([]byte("short"))
+	if _, err := codec.OpenString(shortPayload, "row/a"); err == nil {
+		t.Fatalf("expected short payload to fail")
+	}
+}
+
+func TestNewCodecRejectsInvalidKeyLength(t *testing.T) {
+	t.Parallel()
+
+	if _, err := NewCodec(make([]byte, keySize-1)); err == nil {
+		t.Fatalf("expected short key to fail")
+	}
+	if _, err := NewCodec(make([]byte, keySize+1)); err == nil {
+		t.Fatalf("expected long key to fail")
+	}
+}
+
+func TestNewCodecFromEnv(t *testing.T) {
+	t.Setenv(EnvKeyName, base64.StdEncoding.EncodeToString(make([]byte, keySize)))
+	codec, err := NewCodecFromEnv()
+	if err != nil {
+		t.Fatalf("NewCodecFromEnv: %v", err)
+	}
+	sealed, err := codec.SealString("secret", "row/a")
+	if err != nil {
+		t.Fatalf("SealString: %v", err)
+	}
+	if !strings.HasPrefix(sealed, envelopePrefix) {
+		t.Fatalf("unexpected envelope %q", sealed)
+	}
+}

--- a/internal/tools/decision/tools.go
+++ b/internal/tools/decision/tools.go
@@ -1,0 +1,476 @@
+package decisiontools
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"time"
+
+	"manifold/internal/agent/memory/archaeology"
+	"manifold/internal/agent/memory/artifact"
+	"manifold/internal/agent/memory/belief"
+	decisionmem "manifold/internal/agent/memory/decision"
+	"manifold/internal/auth"
+)
+
+const systemUserID int64 = 0
+
+type searchTool struct {
+	store decisionmem.Store
+}
+
+type reconstructTool struct {
+	service *archaeology.Service
+}
+
+type recordTool struct {
+	service *decisionmem.Service
+}
+
+type reviewTool struct {
+	service *decisionmem.Service
+}
+
+// NewSearchTool returns a tool for retrieving recorded decisions.
+func NewSearchTool(store decisionmem.Store) *searchTool {
+	return &searchTool{store: store}
+}
+
+// NewReconstructTool returns a tool for reconstructing why decisions exist.
+func NewReconstructTool(decisions *decisionmem.Service, beliefs belief.Store, artifacts artifact.Store) *reconstructTool {
+	return &reconstructTool{service: &archaeology.Service{
+		Decisions: decisions,
+		Beliefs:   beliefs,
+		Artifacts: artifacts,
+	}}
+}
+
+// NewRecordTool returns a tool for recording explicit operator decisions.
+func NewRecordTool(service *decisionmem.Service) *recordTool {
+	return &recordTool{service: service}
+}
+
+// NewReviewTool returns a tool for reviewing candidates and lifecycle state.
+func NewReviewTool(service *decisionmem.Service) *reviewTool {
+	return &reviewTool{service: service}
+}
+
+func (t *searchTool) Name() string      { return "decision_search" }
+func (t *reconstructTool) Name() string { return "decision_reconstruct" }
+func (t *recordTool) Name() string      { return "decision_record" }
+func (t *reviewTool) Name() string      { return "decision_review" }
+
+func (t *searchTool) JSONSchema() map[string]any {
+	return map[string]any{
+		"name":        t.Name(),
+		"description": "Search recorded architecture, implementation, and product decisions.",
+		"parameters": map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"query":    map[string]any{"type": "string"},
+				"scopeIds": map[string]any{"type": "array", "items": map[string]any{"type": "string"}},
+				"statuses": map[string]any{"type": "array", "items": map[string]any{
+					"type": "string",
+					"enum": []any{"proposed", "active", "stale", "superseded", "revoked"},
+				}},
+				"limit": map[string]any{"type": "integer", "minimum": 1, "maximum": 50},
+			},
+		},
+	}
+}
+
+func (t *reconstructTool) JSONSchema() map[string]any {
+	return map[string]any{
+		"name":        t.Name(),
+		"description": "Reconstruct the evidence, assumptions, alternatives, and lifecycle history behind matching decisions.",
+		"parameters": map[string]any{
+			"type":     "object",
+			"required": []string{"query"},
+			"properties": map[string]any{
+				"query":        map[string]any{"type": "string"},
+				"scopeIds":     map[string]any{"type": "array", "items": map[string]any{"type": "string"}},
+				"includeStale": map[string]any{"type": "boolean"},
+				"maxDecisions": map[string]any{"type": "integer", "minimum": 1, "maximum": 10},
+				"asOf":         map[string]any{"type": "string", "format": "date-time"},
+			},
+		},
+	}
+}
+
+func (t *recordTool) JSONSchema() map[string]any {
+	return map[string]any{
+		"name":        t.Name(),
+		"description": "Record an explicit decision with optional evidence, assumptions, and rejected alternatives.",
+		"parameters": map[string]any{
+			"type":     "object",
+			"required": []string{"scopeId", "statement"},
+			"properties": map[string]any{
+				"scopeId":     map[string]any{"type": "string"},
+				"episodeId":   map[string]any{"type": "string"},
+				"title":       map[string]any{"type": "string"},
+				"statement":   map[string]any{"type": "string"},
+				"rationale":   map[string]any{"type": "string"},
+				"status":      decisionStatusSchema(),
+				"reviewState": reviewStateSchema(),
+				"confidence":  map[string]any{"type": "number", "minimum": 0, "maximum": 1},
+				"evidence":    evidenceArraySchema(),
+				"assumptions": assumptionArraySchema(),
+				"alternatives": map[string]any{"type": "array", "items": map[string]any{
+					"type":     "object",
+					"required": []string{"statement"},
+					"properties": map[string]any{
+						"statement":       map[string]any{"type": "string"},
+						"rejectionReason": map[string]any{"type": "string"},
+					},
+				}},
+				"metadata": map[string]any{"type": "object"},
+			},
+		},
+	}
+}
+
+func (t *reviewTool) JSONSchema() map[string]any {
+	return map[string]any{
+		"name":        t.Name(),
+		"description": "Review decision candidates or update recorded decision lifecycle state.",
+		"parameters": map[string]any{
+			"type":     "object",
+			"required": []string{"action"},
+			"properties": map[string]any{
+				"action": map[string]any{
+					"type": "string",
+					"enum": []any{"accept_candidate", "reject_candidate", "reaffirm", "revoke", "mark_stale", "needs_review"},
+				},
+				"candidateId":  map[string]any{"type": "string"},
+				"decisionId":   map[string]any{"type": "string"},
+				"reason":       map[string]any{"type": "string"},
+				"triggerId":    map[string]any{"type": "string"},
+				"supersededBy": map[string]any{"type": "string"},
+			},
+		},
+	}
+}
+
+func decisionStatusSchema() map[string]any {
+	return map[string]any{"type": "string", "enum": []any{"proposed", "active", "stale", "superseded", "revoked"}}
+}
+
+func reviewStateSchema() map[string]any {
+	return map[string]any{"type": "string", "enum": []any{"auto_active", "needs_review", "operator_approved", "operator_rejected"}}
+}
+
+func evidenceArraySchema() map[string]any {
+	return map[string]any{"type": "array", "items": map[string]any{
+		"type":     "object",
+		"required": []string{"sourceKind", "sourceId"},
+		"properties": map[string]any{
+			"sourceKind": map[string]any{"type": "string"},
+			"sourceId":   map[string]any{"type": "string"},
+			"polarity":   map[string]any{"type": "string", "enum": []any{"for", "against"}},
+			"weight":     map[string]any{"type": "number"},
+			"note":       map[string]any{"type": "string"},
+		},
+	}}
+}
+
+func assumptionArraySchema() map[string]any {
+	return map[string]any{"type": "array", "items": map[string]any{
+		"type":     "object",
+		"required": []string{"beliefId"},
+		"properties": map[string]any{
+			"beliefId":                  map[string]any{"type": "string"},
+			"criticality":               map[string]any{"type": "string", "enum": []any{"load_bearing", "supporting", "contextual"}},
+			"beliefStatementAtLink":     map[string]any{"type": "string"},
+			"beliefConfidenceAtLink":    map[string]any{"type": "number"},
+			"note":                      map[string]any{"type": "string"},
+			"belief_statement_at_link":  map[string]any{"type": "string"},
+			"belief_confidence_at_link": map[string]any{"type": "number"},
+		},
+	}}
+}
+
+func (t *searchTool) Call(ctx context.Context, raw json.RawMessage) (any, error) {
+	if t == nil || t.store == nil {
+		return nil, decisionmem.ErrStoreRequired
+	}
+	var args struct {
+		Query    string                       `json:"query"`
+		ScopeIDs []string                     `json:"scopeIds"`
+		Statuses []decisionmem.DecisionStatus `json:"statuses"`
+		Limit    int                          `json:"limit"`
+	}
+	if err := json.Unmarshal(raw, &args); err != nil {
+		return nil, err
+	}
+	return t.store.SearchDecisions(ctx, decisionmem.SearchQuery{
+		TenantID: currentTenantID(ctx),
+		Query:    args.Query,
+		ScopeIDs: args.ScopeIDs,
+		Statuses: args.Statuses,
+		Limit:    args.Limit,
+	})
+}
+
+func (t *reconstructTool) Call(ctx context.Context, raw json.RawMessage) (any, error) {
+	if t == nil || t.service == nil {
+		return nil, decisionmem.ErrStoreRequired
+	}
+	var args struct {
+		Query        string   `json:"query"`
+		ScopeIDs     []string `json:"scopeIds"`
+		IncludeStale bool     `json:"includeStale"`
+		MaxDecisions int      `json:"maxDecisions"`
+		AsOf         string   `json:"asOf"`
+	}
+	if err := json.Unmarshal(raw, &args); err != nil {
+		return nil, err
+	}
+	var asOf *time.Time
+	if strings.TrimSpace(args.AsOf) != "" {
+		parsed, err := time.Parse(time.RFC3339, strings.TrimSpace(args.AsOf))
+		if err != nil {
+			return nil, err
+		}
+		asOf = &parsed
+	}
+	return t.service.Reconstruct(ctx, currentTenantID(ctx), args.Query, archaeology.ReconstructOptions{
+		ScopeIDs:     args.ScopeIDs,
+		AsOf:         asOf,
+		IncludeStale: args.IncludeStale,
+		MaxDecisions: args.MaxDecisions,
+	})
+}
+
+func (t *recordTool) Call(ctx context.Context, raw json.RawMessage) (any, error) {
+	if t == nil || t.service == nil || t.service.Store == nil {
+		return nil, decisionmem.ErrStoreRequired
+	}
+	var args recordArgs
+	if err := json.Unmarshal(raw, &args); err != nil {
+		return nil, err
+	}
+	tenantID := currentTenantID(ctx)
+	actor := currentActorUserID(ctx)
+	recorded, err := t.service.CreateDecision(ctx, decisionmem.Decision{
+		TenantID:    tenantID,
+		ScopeID:     strings.TrimSpace(args.ScopeID),
+		EpisodeID:   strings.TrimSpace(args.EpisodeID),
+		Title:       strings.TrimSpace(args.Title),
+		Statement:   strings.TrimSpace(args.Statement),
+		Rationale:   strings.TrimSpace(args.Rationale),
+		DecidedBy:   decidedBy(actor),
+		Status:      decisionmem.NormalizeDecisionStatus(args.Status),
+		ReviewState: decisionmem.NormalizeReviewState(args.ReviewState),
+		Confidence:  args.Confidence,
+		Metadata:    args.Metadata,
+	})
+	if err != nil {
+		return nil, err
+	}
+	evidence, assumptions, alternatives, err := t.attachContext(ctx, tenantID, recorded.ID, args)
+	if err != nil {
+		return nil, err
+	}
+	return map[string]any{
+		"decision":     recorded,
+		"evidence":     evidence,
+		"assumptions":  assumptions,
+		"alternatives": alternatives,
+	}, nil
+}
+
+func (t *recordTool) attachContext(ctx context.Context, tenantID int64, decisionID string, args recordArgs) ([]decisionmem.DecisionEvidence, []decisionmem.AssumptionLink, []decisionmem.Alternative, error) {
+	evidence := make([]decisionmem.DecisionEvidence, 0, len(args.Evidence))
+	for _, ev := range args.Evidence {
+		if strings.TrimSpace(ev.SourceKind) == "" || strings.TrimSpace(ev.SourceID) == "" {
+			continue
+		}
+		if ev.Weight == 0 {
+			ev.Weight = 1
+		}
+		created, err := t.service.Store.AddEvidence(ctx, decisionmem.DecisionEvidence{
+			TenantID:   tenantID,
+			DecisionID: decisionID,
+			SourceKind: strings.TrimSpace(ev.SourceKind),
+			SourceID:   strings.TrimSpace(ev.SourceID),
+			Polarity:   decisionmem.NormalizeEvidencePolarity(ev.Polarity),
+			Weight:     ev.Weight,
+			Note:       strings.TrimSpace(ev.Note),
+		})
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		evidence = append(evidence, created)
+	}
+	assumptions := make([]decisionmem.AssumptionLink, 0, len(args.Assumptions))
+	for _, assumption := range args.Assumptions {
+		if strings.TrimSpace(assumption.BeliefID) == "" {
+			continue
+		}
+		statement := firstNonEmpty(assumption.BeliefStatementAtLink, assumption.BeliefStatementAtLinkSnake)
+		confidence := assumption.BeliefConfidenceAtLink
+		if confidence == 0 {
+			confidence = assumption.BeliefConfidenceAtLinkSnake
+		}
+		created, err := t.service.Store.AddAssumption(ctx, decisionmem.AssumptionLink{
+			TenantID:               tenantID,
+			DecisionID:             decisionID,
+			BeliefID:               strings.TrimSpace(assumption.BeliefID),
+			Criticality:            decisionmem.NormalizeAssumptionCriticality(assumption.Criticality),
+			BeliefStatementAtLink:  strings.TrimSpace(statement),
+			BeliefConfidenceAtLink: confidence,
+			Note:                   strings.TrimSpace(assumption.Note),
+		})
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		assumptions = append(assumptions, created)
+	}
+	alternatives := make([]decisionmem.Alternative, 0, len(args.Alternatives))
+	for _, alt := range args.Alternatives {
+		if strings.TrimSpace(alt.Statement) == "" {
+			continue
+		}
+		created, err := t.service.Store.AddAlternative(ctx, decisionmem.Alternative{
+			TenantID:        tenantID,
+			DecisionID:      decisionID,
+			Statement:       strings.TrimSpace(alt.Statement),
+			RejectionReason: strings.TrimSpace(alt.RejectionReason),
+		})
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		alternatives = append(alternatives, created)
+	}
+	return evidence, assumptions, alternatives, nil
+}
+
+func (t *reviewTool) Call(ctx context.Context, raw json.RawMessage) (any, error) {
+	if t == nil || t.service == nil || t.service.Store == nil {
+		return nil, decisionmem.ErrStoreRequired
+	}
+	var args struct {
+		Action       string `json:"action"`
+		CandidateID  string `json:"candidateId"`
+		DecisionID   string `json:"decisionId"`
+		Reason       string `json:"reason"`
+		TriggerID    string `json:"triggerId"`
+		SupersededBy string `json:"supersededBy"`
+	}
+	if err := json.Unmarshal(raw, &args); err != nil {
+		return nil, err
+	}
+	tenantID := currentTenantID(ctx)
+	actor := currentActorUserID(ctx)
+	switch strings.TrimSpace(args.Action) {
+	case "accept_candidate":
+		return t.service.AcceptCandidate(ctx, tenantID, args.CandidateID, actor)
+	case "reject_candidate":
+		return t.rejectCandidate(ctx, tenantID, args.CandidateID, args.Reason)
+	case "reaffirm":
+		return t.service.ReaffirmDecision(ctx, tenantID, args.DecisionID, args.Reason, actor)
+	case "revoke":
+		return t.service.RevokeDecision(ctx, tenantID, args.DecisionID, args.Reason, actor)
+	case "mark_stale":
+		return t.service.TransitionDecision(ctx, tenantID, args.DecisionID, decisionmem.DecisionStatusStale, decisionmem.TransitionRequest{
+			Reason:       args.Reason,
+			TriggerKind:  decisionmem.TriggerOperator,
+			TriggerID:    args.TriggerID,
+			ActorUserID:  actor,
+			SupersededBy: args.SupersededBy,
+		})
+	case "needs_review":
+		return t.service.MarkNeedsReview(ctx, tenantID, args.DecisionID, args.Reason, args.TriggerID)
+	default:
+		return nil, errors.New("unsupported decision review action")
+	}
+}
+
+func (t *reviewTool) rejectCandidate(ctx context.Context, tenantID int64, candidateID, reason string) (decisionmem.Candidate, error) {
+	candidate, ok, err := t.service.Store.GetCandidate(ctx, tenantID, strings.TrimSpace(candidateID))
+	if err != nil || !ok {
+		if err != nil {
+			return decisionmem.Candidate{}, err
+		}
+		return decisionmem.Candidate{}, errors.New("candidate not found")
+	}
+	candidate.ValidationStatus = decisionmem.CandidateValidationRejected
+	candidate.ReviewState = decisionmem.ReviewStateOperatorRejected
+	candidate.RejectionReason = strings.TrimSpace(reason)
+	return t.service.Store.RecordCandidate(ctx, candidate)
+}
+
+type recordArgs struct {
+	ScopeID      string                     `json:"scopeId"`
+	EpisodeID    string                     `json:"episodeId"`
+	Title        string                     `json:"title"`
+	Statement    string                     `json:"statement"`
+	Rationale    string                     `json:"rationale"`
+	Status       decisionmem.DecisionStatus `json:"status"`
+	ReviewState  decisionmem.ReviewState    `json:"reviewState"`
+	Confidence   float64                    `json:"confidence"`
+	Evidence     []recordEvidenceArg        `json:"evidence"`
+	Assumptions  []recordAssumptionArg      `json:"assumptions"`
+	Alternatives []recordAlternativeArg     `json:"alternatives"`
+	Metadata     map[string]any             `json:"metadata"`
+}
+
+type recordEvidenceArg struct {
+	SourceKind string                       `json:"sourceKind"`
+	SourceID   string                       `json:"sourceId"`
+	Polarity   decisionmem.EvidencePolarity `json:"polarity"`
+	Weight     float64                      `json:"weight"`
+	Note       string                       `json:"note"`
+}
+
+type recordAssumptionArg struct {
+	BeliefID                    string                            `json:"beliefId"`
+	Criticality                 decisionmem.AssumptionCriticality `json:"criticality"`
+	BeliefStatementAtLink       string                            `json:"beliefStatementAtLink"`
+	BeliefConfidenceAtLink      float64                           `json:"beliefConfidenceAtLink"`
+	BeliefStatementAtLinkSnake  string                            `json:"belief_statement_at_link"`
+	BeliefConfidenceAtLinkSnake float64                           `json:"belief_confidence_at_link"`
+	Note                        string                            `json:"note"`
+}
+
+type recordAlternativeArg struct {
+	Statement       string `json:"statement"`
+	RejectionReason string `json:"rejectionReason"`
+}
+
+func currentTenantID(ctx context.Context) int64 {
+	if user, ok := auth.CurrentUser(ctx); ok && user != nil {
+		return user.ID
+	}
+	return systemUserID
+}
+
+func currentActorUserID(ctx context.Context) *int64 {
+	if user, ok := auth.CurrentUser(ctx); ok && user != nil {
+		id := user.ID
+		return &id
+	}
+	return nil
+}
+
+func decidedBy(actor *int64) string {
+	if actor == nil {
+		return "tool:decision_record"
+	}
+	return "human:" + jsonNumber(*actor)
+}
+
+func jsonNumber(value int64) string {
+	b, _ := json.Marshal(value)
+	return string(b)
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/internal/tools/decision/tools_test.go
+++ b/internal/tools/decision/tools_test.go
@@ -1,0 +1,111 @@
+package decisiontools
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"manifold/internal/agent/memory/archaeology"
+	decisionmem "manifold/internal/agent/memory/decision"
+	"manifold/internal/auth"
+	"manifold/internal/persistence/databases"
+)
+
+func TestRecordSearchAndReconstructTools(t *testing.T) {
+	t.Parallel()
+	ctx := auth.WithUser(context.Background(), &auth.User{ID: 7})
+	store := databases.NewMemoryDecisionStore()
+	service := &decisionmem.Service{Store: store}
+
+	recorded, err := NewRecordTool(service).Call(ctx, json.RawMessage(`{
+		"scopeId":"scope-1",
+		"statement":"Use PostgreSQL JSONB payloads for decision archaeology stores.",
+		"rationale":"The typed columns support filters while payloads preserve forward-compatible records.",
+		"confidence":0.86,
+		"evidence":[{"sourceKind":"artifact","sourceId":"artifact-1","polarity":"for","note":"implementation patch"}],
+		"assumptions":[{"beliefId":"belief-1","criticality":"load_bearing","beliefStatementAtLink":"PostgreSQL is configured","beliefConfidenceAtLink":0.9}],
+		"alternatives":[{"statement":"Use memory-only stores","rejectionReason":"not durable"}]
+	}`))
+	if err != nil {
+		t.Fatalf("decision_record error = %v", err)
+	}
+	payload := recorded.(map[string]any)
+	decision := payload["decision"].(decisionmem.Decision)
+	if decision.TenantID != 7 || decision.Status != decisionmem.DecisionStatusActive || decision.DecidedBy != "human:7" {
+		t.Fatalf("unexpected recorded decision: %#v", decision)
+	}
+
+	results, err := NewSearchTool(store).Call(ctx, json.RawMessage(`{"query":"JSONB","scopeIds":["scope-1"]}`))
+	if err != nil {
+		t.Fatalf("decision_search error = %v", err)
+	}
+	searchResults := results.([]decisionmem.SearchResult)
+	if len(searchResults) != 1 || searchResults[0].Decision.ID != decision.ID {
+		t.Fatalf("unexpected search results: %#v", searchResults)
+	}
+
+	report, err := NewReconstructTool(service, nil, nil).Call(ctx, json.RawMessage(`{"query":"JSONB","scopeIds":["scope-1"],"includeStale":true}`))
+	if err != nil {
+		t.Fatalf("decision_reconstruct error = %v", err)
+	}
+	reconstructed := report.(archaeology.Report)
+	if len(reconstructed.Decisions) != 1 || reconstructed.Decisions[0].Decision.ID != decision.ID {
+		t.Fatalf("unexpected reconstruction report: %#v", reconstructed)
+	}
+	lineage, ok, err := service.LoadLineage(ctx, 7, decision.ID)
+	if err != nil || !ok {
+		t.Fatalf("LoadLineage() ok=%v error=%v", ok, err)
+	}
+	if len(lineage.Evidence) != 1 || len(lineage.Assumptions) != 1 || len(lineage.Alternatives) != 1 {
+		t.Fatalf("expected attached context, got %#v", lineage)
+	}
+}
+
+func TestReviewToolAcceptsAndRejectsCandidates(t *testing.T) {
+	t.Parallel()
+	ctx := auth.WithUser(context.Background(), &auth.User{ID: 7})
+	store := databases.NewMemoryDecisionStore()
+	service := &decisionmem.Service{Store: store}
+	candidate, err := store.RecordCandidate(ctx, decisionmem.Candidate{
+		TenantID:         7,
+		ScopeID:          "scope-1",
+		Title:            "Use durable decisions",
+		Statement:        "Persist decisions in the configured database.",
+		Rationale:        "Recovered context must survive process restarts.",
+		Confidence:       0.8,
+		ReviewState:      decisionmem.ReviewStateNeedsReview,
+		ValidationStatus: decisionmem.CandidateValidationQueued,
+	})
+	if err != nil {
+		t.Fatalf("RecordCandidate() error = %v", err)
+	}
+	accepted, err := NewReviewTool(service).Call(ctx, json.RawMessage(`{"action":"accept_candidate","candidateId":"`+candidate.ID+`"}`))
+	if err != nil {
+		t.Fatalf("accept candidate error = %v", err)
+	}
+	decision := accepted.(decisionmem.Decision)
+	if decision.Status != decisionmem.DecisionStatusActive || decision.ReviewState != decisionmem.ReviewStateOperatorApproved {
+		t.Fatalf("unexpected accepted decision: %#v", decision)
+	}
+
+	rejectedCandidate, err := store.RecordCandidate(ctx, decisionmem.Candidate{
+		TenantID:         7,
+		ScopeID:          "scope-1",
+		Title:            "Use transient decisions",
+		Statement:        "Keep decisions only in process memory.",
+		Confidence:       0.7,
+		ReviewState:      decisionmem.ReviewStateNeedsReview,
+		ValidationStatus: decisionmem.CandidateValidationQueued,
+	})
+	if err != nil {
+		t.Fatalf("RecordCandidate() error = %v", err)
+	}
+	rejected, err := NewReviewTool(service).Call(ctx, json.RawMessage(`{"action":"reject_candidate","candidateId":"`+rejectedCandidate.ID+`","reason":"not durable"}`))
+	if err != nil {
+		t.Fatalf("reject candidate error = %v", err)
+	}
+	rejectedRecord := rejected.(decisionmem.Candidate)
+	if rejectedRecord.ValidationStatus != decisionmem.CandidateValidationRejected || rejectedRecord.ReviewState != decisionmem.ReviewStateOperatorRejected {
+		t.Fatalf("unexpected rejected candidate: %#v", rejectedRecord)
+	}
+}

--- a/web/agentd-ui/src/api/chatStream.ts
+++ b/web/agentd-ui/src/api/chatStream.ts
@@ -68,6 +68,7 @@ export interface ChatStreamEvent {
   token_estimate?: number;
   truncated?: boolean;
   duration_ms?: number;
+  durationMs?: number;
   lanes?: Record<string, ChatMemoryContextLane>;
   phase?: string;
   context_window?: number;
@@ -266,7 +267,12 @@ export async function streamChatRunEvents(options: {
     cache: "no-store",
     signal,
   });
-  await streamAgentResponse(response, new TextDecoder(), onEvent, "chat run events");
+  await streamAgentResponse(
+    response,
+    new TextDecoder(),
+    onEvent,
+    "chat run events",
+  );
 }
 
 export async function cancelChatRun(runId: string): Promise<void> {
@@ -290,7 +296,9 @@ export async function resumeChatRun(
   );
   if (!response.ok) {
     const text = await response.text().catch(() => "");
-    throw new Error(text.trim() || `chat run resume failed (${response.status})`);
+    throw new Error(
+      text.trim() || `chat run resume failed (${response.status})`,
+    );
   }
   return (await response.json()) as ChatRunResumeResponse;
 }
@@ -474,7 +482,19 @@ async function emitJSONFinal(
     typeof body.result === "string"
       ? body.result
       : "";
-  onEvent({ type: "final", data: result });
+  const durationMs =
+    body && typeof body === "object"
+      ? (numericDuration((body as Record<string, unknown>).durationMs) ??
+        numericDuration((body as Record<string, unknown>).duration_ms))
+      : undefined;
+  const event: ChatStreamEvent = { type: "final", data: result };
+  if (durationMs !== undefined) event.durationMs = durationMs;
+  onEvent(event);
+}
+
+function numericDuration(value: unknown) {
+  const duration = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(duration) && duration >= 0 ? duration : undefined;
 }
 
 async function readEventStream(

--- a/web/agentd-ui/src/stores/chatStreamEvents.ts
+++ b/web/agentd-ui/src/stores/chatStreamEvents.ts
@@ -107,9 +107,11 @@ export function handleStreamEvent(
     }
     case "final": {
       const text = typeof event.data === "string" ? event.data : "";
+      const durationMs = eventDurationMs(event);
       state.updateMessage(sessionId, assistantId, (m) => ({
         ...m,
         content: text || m.content,
+        durationMs: durationMs ?? m.durationMs,
         contextMetrics: withEstimatedAssistantTokens(
           m.contextMetrics,
           text || m.content,
@@ -199,6 +201,12 @@ export function handleStreamEvent(
     default:
       break;
   }
+}
+
+function eventDurationMs(event: ChatStreamEvent) {
+  const raw = event.durationMs ?? event.duration_ms;
+  const duration = typeof raw === "number" ? raw : Number(raw);
+  return Number.isFinite(duration) && duration >= 0 ? duration : undefined;
 }
 
 function eventSequence(event: ChatStreamEvent) {

--- a/web/agentd-ui/src/types/chat.ts
+++ b/web/agentd-ui/src/types/chat.ts
@@ -93,6 +93,7 @@ export interface ChatMessage {
   role: ChatRole;
   content: string;
   createdAt: string;
+  durationMs?: number;
   streaming?: boolean;
   title?: string;
   error?: string;

--- a/web/agentd-ui/src/views/ChatView.vue
+++ b/web/agentd-ui/src/views/ChatView.vue
@@ -387,7 +387,7 @@
                       : 'Response time'
                   "
                 >
-                  {{ formatDuration(responseElapsedMs(message.id)) }}
+                  {{ formatDuration(responseElapsedMs(message)) }}
                 </span>
                 <span
                   v-if="message.streaming"
@@ -2310,7 +2310,8 @@ const sessionMessageCounts = computed<Record<string, number>>(() => {
   const counts: Record<string, number> = {};
   for (const session of sessions.value) {
     const local = messagesBySession.value[session.id];
-    const metaCount = session.messageCount ?? 0;
+    const metaCount =
+      typeof session.messageCount === "number" ? session.messageCount : 0;
     if (Array.isArray(local) && local.length) {
       counts[session.id] = local.length;
     } else {
@@ -2361,8 +2362,6 @@ function sessionRowClasses(sessionId: string) {
 }
 
 // --- Response timer (elapsed while streaming; frozen when stream completes) ---
-// Note: historical messages loaded from the server won't have timing info; we only
-// show timers for messages created/streamed during this UI session.
 const responseStartMsByMessageId = new Map<string, number>();
 const responseElapsedMsByMessageId = ref<Record<string, number>>({});
 const responseIntervalByMessageId = new Map<string, number>();
@@ -2372,8 +2371,18 @@ function safeParseIsoMs(iso: string) {
   return Number.isFinite(ms) ? ms : null;
 }
 
-function responseElapsedMs(messageId: string) {
-  return responseElapsedMsByMessageId.value[messageId] ?? 0;
+function persistedResponseDurationMs(message: ChatMessage) {
+  const duration =
+    typeof message.durationMs === "number" ? message.durationMs : Number.NaN;
+  return Number.isFinite(duration) && duration >= 0 ? duration : undefined;
+}
+
+function responseElapsedMs(message: ChatMessage) {
+  if (!message.streaming) {
+    const persisted = persistedResponseDurationMs(message);
+    if (persisted !== undefined) return persisted;
+  }
+  return responseElapsedMsByMessageId.value[message.id] ?? 0;
 }
 
 function formatDuration(ms: number) {
@@ -2394,7 +2403,7 @@ function ensureResponseTimer(message: ChatMessage) {
     const start =
       typeof previousElapsed === "number" && previousElapsed > 0
         ? Date.now() - previousElapsed
-        : safeParseIsoMs(message.createdAt) ?? Date.now();
+        : (safeParseIsoMs(message.createdAt) ?? Date.now());
     responseStartMsByMessageId.set(id, start);
   }
 
@@ -2413,7 +2422,7 @@ function ensureResponseTimer(message: ChatMessage) {
   }
 }
 
-function stopResponseTimer(messageId: string, pause = false) {
+function updateLocalResponseElapsed(messageId: string) {
   const start = responseStartMsByMessageId.get(messageId);
   if (start) {
     responseElapsedMsByMessageId.value[messageId] = Math.max(
@@ -2421,9 +2430,9 @@ function stopResponseTimer(messageId: string, pause = false) {
       Date.now() - start,
     );
   }
-  if (pause) {
-    responseStartMsByMessageId.delete(messageId);
-  }
+}
+
+function clearResponseTimerInterval(messageId: string) {
   const handle = responseIntervalByMessageId.get(messageId);
   if (handle != null) {
     if (isBrowser) window.clearInterval(handle);
@@ -2431,16 +2440,39 @@ function stopResponseTimer(messageId: string, pause = false) {
   }
 }
 
+function suspendResponseTimer(messageId: string) {
+  updateLocalResponseElapsed(messageId);
+  clearResponseTimerInterval(messageId);
+}
+
+function pauseResponseTimer(messageId: string) {
+  updateLocalResponseElapsed(messageId);
+  responseStartMsByMessageId.delete(messageId);
+  clearResponseTimerInterval(messageId);
+}
+
+function finalizeResponseTimer(message: ChatMessage) {
+  const persisted = persistedResponseDurationMs(message);
+  if (persisted !== undefined) {
+    responseElapsedMsByMessageId.value[message.id] = persisted;
+  } else {
+    updateLocalResponseElapsed(message.id);
+  }
+  responseStartMsByMessageId.delete(message.id);
+  clearResponseTimerInterval(message.id);
+}
+
 function stopAllResponseTimers() {
-  // Iterate a snapshot since stopResponseTimer mutates the map.
+  // Iterate a snapshot since suspending mutates the interval map.
   for (const id of Array.from(responseIntervalByMessageId.keys())) {
-    stopResponseTimer(id);
+    suspendResponseTimer(id);
   }
 }
 
 function shouldShowResponseTimer(message: ChatMessage) {
   if (message.role !== "assistant") return false;
   if (message.streaming) return true;
+  if (persistedResponseDurationMs(message) !== undefined) return true;
   return message.id in responseElapsedMsByMessageId.value;
 }
 
@@ -3156,14 +3188,12 @@ function teamOrchestratorModel(team: SpecialistTeam) {
   const orchestrator = teamOrchestratorName(team);
   if (orchestrator) {
     return (
-      (specialistsByName.value.get(orchestrator.toLowerCase())?.model || "")
-        .trim() || ""
+      (
+        specialistsByName.value.get(orchestrator.toLowerCase())?.model || ""
+      ).trim() || ""
     );
   }
-  return (
-    sessionAgentDefaults.value.model ||
-    ""
-  );
+  return sessionAgentDefaults.value.model || "";
 }
 
 function teamOrchestratorParticipant(team: SpecialistTeam): Participant | null {
@@ -3271,8 +3301,7 @@ function participantIsActive(participant: Participant) {
       : "";
     const liveKey =
       liveTeam &&
-      (liveAgent === liveTeamOrchestrator ||
-        liveAgent === "orchestrator")
+      (liveAgent === liveTeamOrchestrator || liveAgent === "orchestrator")
         ? `team:${liveTeam.toLowerCase()}:orchestrator`
         : `specialist:${(
             liveAgent ||
@@ -3461,13 +3490,20 @@ watch(
 // Keep response timers in sync with streaming lifecycle.
 watch(
   () =>
-    activeMessages.value.map((m) => `${m.id}:${m.role}:${m.streaming ? 1 : 0}`),
+    activeMessages.value.map(
+      (m) => `${m.id}:${m.role}:${m.streaming ? 1 : 0}:${m.durationMs ?? ""}`,
+    ),
   () => {
     for (const msg of activeMessages.value) {
       if (msg.role !== "assistant") continue;
       if (msg.streaming) ensureResponseTimer(msg);
-      else if (msg.id in responseElapsedMsByMessageId.value)
-        stopResponseTimer(msg.id, Boolean(msg.error));
+      else if (
+        persistedResponseDurationMs(msg) !== undefined ||
+        msg.id in responseElapsedMsByMessageId.value
+      ) {
+        if (msg.error) pauseResponseTimer(msg.id);
+        else finalizeResponseTimer(msg);
+      }
     }
   },
   { flush: "post" },
@@ -3862,10 +3898,10 @@ function stopStreaming() {
 function canResumeDurableRun(message: ChatMessage) {
   return Boolean(
     message.role === "assistant" &&
-      message.error &&
-      message.runId &&
-      !message.streaming &&
-      !isStreaming.value,
+    message.error &&
+    message.runId &&
+    !message.streaming &&
+    !isStreaming.value,
   );
 }
 

--- a/web/agentd-ui/tests/chatResume.test.ts
+++ b/web/agentd-ui/tests/chatResume.test.ts
@@ -51,6 +51,7 @@ describe("chat durable resume", () => {
     chatApiMocks.resumeChatRun.mockResolvedValue({
       run_id: "run-1",
       status: "queued",
+      retried: true,
       last_sequence: 8,
       last_retry_sequence: 8,
     });
@@ -60,7 +61,12 @@ describe("chat durable resume", () => {
         onEvent: (event: ChatStreamEvent) => void;
       }) => {
         options.onEvent({ type: "delta", data: " resumed", sequence: 9 });
-        options.onEvent({ type: "final", data: "old work resumed", sequence: 10 });
+        options.onEvent({
+          type: "final",
+          data: "old work resumed",
+          sequence: 10,
+          durationMs: 1234,
+        });
       },
     );
 
@@ -79,6 +85,7 @@ describe("chat durable resume", () => {
     expect(message.streaming).toBe(false);
     expect(message.error).toBeUndefined();
     expect(message.content).toBe("old work resumed");
+    expect(message.durationMs).toBe(1234);
     expect(message.lastRunSequence).toBe(10);
   });
 });

--- a/web/agentd-ui/tests/chatStream.test.ts
+++ b/web/agentd-ui/tests/chatStream.test.ts
@@ -18,6 +18,22 @@ function makeSSEStream(chunks: string[]) {
   });
 }
 
+function makeStartRunResponse(runId = "run-1", sessionId = "abc") {
+  return new Response(
+    JSON.stringify({
+      run_id: runId,
+      session_id: sessionId,
+      user_message_id: "user-1",
+      assistant_message_id: "assistant-1",
+      status: "running",
+    }),
+    {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    },
+  );
+}
+
 describe("extractEventPayload", () => {
   it("parses a simple SSE payload", () => {
     const raw = 'data: {"type":"delta","data":"hi"}';
@@ -47,7 +63,10 @@ describe("streamAgentRun", () => {
       headers: { "Content-Type": "text/event-stream" },
     });
 
-    const fetchMock = vi.fn().mockResolvedValue(response);
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(makeStartRunResponse())
+      .mockResolvedValueOnce(response);
     const received: ChatStreamEvent[] = [];
 
     await streamAgentRun({
@@ -58,6 +77,7 @@ describe("streamAgentRun", () => {
     });
 
     expect(received).toEqual([
+      { type: "run_started", run_id: "run-1", session_id: "abc" },
       { type: "delta", data: "Hello" },
       { type: "final", data: "Hello world" },
     ]);
@@ -69,7 +89,10 @@ describe("streamAgentRun", () => {
       headers: { "Content-Type": "application/json" },
     });
 
-    const fetchMock = vi.fn().mockResolvedValue(response);
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(makeStartRunResponse("run-json", ""))
+      .mockResolvedValueOnce(response);
     const received: ChatStreamEvent[] = [];
 
     await streamAgentRun({
@@ -78,7 +101,37 @@ describe("streamAgentRun", () => {
       fetchImpl: fetchMock,
     });
 
-    expect(received).toEqual([{ type: "final", data: "done" }]);
+    expect(received).toEqual([
+      { type: "run_started", run_id: "run-json", session_id: "" },
+      { type: "final", data: "done" },
+    ]);
+  });
+
+  it("preserves duration from non-streaming JSON responses", async () => {
+    const response = new Response(
+      JSON.stringify({ result: "done", durationMs: 12437 }),
+      {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(makeStartRunResponse("run-duration", ""))
+      .mockResolvedValueOnce(response);
+    const received: ChatStreamEvent[] = [];
+
+    await streamAgentRun({
+      prompt: "hello",
+      onEvent: (event) => received.push(event),
+      fetchImpl: fetchMock,
+    });
+
+    expect(received).toEqual([
+      { type: "run_started", run_id: "run-duration", session_id: "" },
+      { type: "final", data: "done", durationMs: 12437 },
+    ]);
   });
 
   it("includes memory settings in the run payload", async () => {
@@ -86,7 +139,10 @@ describe("streamAgentRun", () => {
       status: 200,
       headers: { "Content-Type": "application/json" },
     });
-    const fetchMock = vi.fn().mockResolvedValue(response);
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(makeStartRunResponse())
+      .mockResolvedValueOnce(response);
 
     await streamAgentRun({
       prompt: "hello",
@@ -109,7 +165,10 @@ describe("streamAgentRun", () => {
       status: 200,
       headers: { "Content-Type": "application/json" },
     });
-    const fetchMock = vi.fn().mockResolvedValue(response);
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(makeStartRunResponse())
+      .mockResolvedValueOnce(response);
 
     await streamAgentRun({
       prompt: "hello",
@@ -118,6 +177,8 @@ describe("streamAgentRun", () => {
       fetchImpl: fetchMock,
     });
 
-    expect(String(fetchMock.mock.calls[0]?.[0])).toBe("/agent/run?team=ops");
+    expect(String(fetchMock.mock.calls[0]?.[0])).toBe(
+      "/api/chat/runs?team=ops",
+    );
   });
 });

--- a/web/agentd-ui/tests/views/chatview-delete-session.spec.ts
+++ b/web/agentd-ui/tests/views/chatview-delete-session.spec.ts
@@ -116,7 +116,9 @@ describe("ChatView conversation delete", () => {
   });
 
   it("shows cancel/delete confirmation before deleting a conversation", async () => {
-    const { findByRole, getByRole } = render(ChatView);
+    const { findByRole, findByText, getByRole } = render(ChatView);
+
+    expect(await findByText("1 msg")).toBeTruthy();
 
     const openDeleteDialog = await findByRole("button", {
       name: /Delete conversation Roadmap Chat/i,


### PR DESCRIPTION
## Summary

This pull request brings together the latest Manifold work from `idev` into `develop`, focused on durable agent memory, decision archaeology, and secure persistence foundations.

Key changes include:

- Add context archaeology and artifact capture services for recovering useful project context from chat, git, tickets, and transit sources.
- Introduce decision memory infrastructure, including lifecycle/lineage models, distillation, persistence stores, and decision tools.
- Encrypt database-stored secrets and add shared secret codec support with coverage across memory, SQLite, and Postgres stores.
- Persist richer chat session metadata, including durations and message counts, and update chat stream/UI handling accordingly.
- Expand Magma/evolving memory lifecycle capabilities and graph views.
- Add documentation and example configuration for storage, context archaeology, and memory features.
- Add broad test coverage for the new persistence, memory, decision, artifact, secret, and UI stream behavior.

## Implementation notes

The changes span backend memory services, database persistence layers, agent runtime wiring, tool registration, configuration defaults, documentation, and frontend chat stream handling. The branch is clean locally and includes 90 changed files with the feature commits currently on `idev`.

## Credit

These changes were planned and implemented by **Manifold**.

## Validation

- Added and updated unit/integration tests across memory, persistence, decision, artifact, secrets, and frontend chat behavior.
- Verified the local working tree is clean before opening this PR.