### PR TITLE
fix(auth): escape user fields in /me JSON response

### DIFF
--- a/internal/auth/oauth2.go
+++ b/internal/auth/oauth2.go
@@ -363,12 +363,17 @@ func (o *OAuth2) LogoutHandler(cookieSecure bool, cookieDomain string) http.Hand
 func (o *OAuth2) MeHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
+		enc := json.NewEncoder(w)
 		if u, ok := CurrentUser(r.Context()); ok && u != nil {
-			_, _ = w.Write([]byte(`{"email":"` + u.Email + `","name":"` + u.Name + `","picture":"` + u.Picture + `"}`))
+			_ = enc.Encode(map[string]string{
+				"email":   u.Email,
+				"name":    u.Name,
+				"picture": u.Picture,
+			})
 			return
 		}
 		w.WriteHeader(http.StatusUnauthorized)
-		_, _ = w.Write([]byte(`{"error":"unauthorized"}`))
+		_ = enc.Encode(map[string]string{"error": "unauthorized"})
 	}
 }
 

--- a/internal/auth/oauth2_test.go
+++ b/internal/auth/oauth2_test.go
@@ -2,6 +2,10 @@ package auth
 
 import (
 	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -57,6 +61,59 @@ func TestDig(t *testing.T) {
 	}
 	if _, ok := dig(payload, "profile.missing"); ok {
 		t.Fatalf("expected missing path to be false")
+	}
+}
+
+func TestOAuth2MeHandlerEscapesUserFields(t *testing.T) {
+	t.Parallel()
+	user := &User{
+		Email:   `mike+test@example.com`,
+		Name:    `O'Brien "the Magnificent"`,
+		Picture: `https://cdn.example.com/p.jpg?q="x"`,
+	}
+	req := httptest.NewRequest(http.MethodGet, "/api/me", nil)
+	req = req.WithContext(WithUser(req.Context(), user))
+	rec := httptest.NewRecorder()
+
+	(&OAuth2{}).MeHandler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if ct := rec.Header().Get("Content-Type"); !strings.HasPrefix(ct, "application/json") {
+		t.Fatalf("unexpected content-type: %q", ct)
+	}
+	var got map[string]string
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("response is not valid JSON: %v\nbody: %s", err, rec.Body.String())
+	}
+	if got["email"] != user.Email {
+		t.Fatalf("email round-trip failed: want %q got %q", user.Email, got["email"])
+	}
+	if got["name"] != user.Name {
+		t.Fatalf("name round-trip failed: want %q got %q", user.Name, got["name"])
+	}
+	if got["picture"] != user.Picture {
+		t.Fatalf("picture round-trip failed: want %q got %q", user.Picture, got["picture"])
+	}
+}
+
+func TestOAuth2MeHandlerUnauthorized(t *testing.T) {
+	t.Parallel()
+	req := httptest.NewRequest(http.MethodGet, "/api/me", nil)
+	rec := httptest.NewRecorder()
+
+	(&OAuth2{}).MeHandler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", rec.Code)
+	}
+	var got map[string]string
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("response is not valid JSON: %v\nbody: %s", err, rec.Body.String())
+	}
+	if got["error"] != "unauthorized" {
+		t.Fatalf("expected error=unauthorized, got %v", got)
 	}
 }
 

--- a/internal/auth/oidc.go
+++ b/internal/auth/oidc.go
@@ -444,11 +444,16 @@ func claimsContain(c Claims, want string) bool {
 func (o *OIDC) MeHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
+		enc := json.NewEncoder(w)
 		if u, ok := CurrentUser(r.Context()); ok && u != nil {
-			_, _ = w.Write([]byte(`{"email":"` + u.Email + `","name":"` + u.Name + `","picture":"` + u.Picture + `"}`))
+			_ = enc.Encode(map[string]string{
+				"email":   u.Email,
+				"name":    u.Name,
+				"picture": u.Picture,
+			})
 			return
 		}
 		w.WriteHeader(http.StatusUnauthorized)
-		_, _ = w.Write([]byte(`{"error":"unauthorized"}`))
+		_ = enc.Encode(map[string]string{"error": "unauthorized"})
 	}
 }

--- a/internal/auth/oidc_test.go
+++ b/internal/auth/oidc_test.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -62,6 +63,59 @@ func TestOIDCLogoutLocalWhenNoLogoutURL(t *testing.T) {
 	}
 	if got := rec.Header().Get("Location"); got != "http://example.com/signed-out" {
 		t.Fatalf("unexpected location: %q", got)
+	}
+}
+
+func TestOIDCMeHandlerEscapesUserFields(t *testing.T) {
+	t.Parallel()
+	user := &User{
+		Email:   `mike+test@example.com`,
+		Name:    `O'Brien "the Magnificent"`,
+		Picture: `https://cdn.example.com/p.jpg?q="x"`,
+	}
+	req := httptest.NewRequest(http.MethodGet, "/api/me", nil)
+	req = req.WithContext(WithUser(req.Context(), user))
+	rec := httptest.NewRecorder()
+
+	(&OIDC{}).MeHandler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if ct := rec.Header().Get("Content-Type"); !strings.HasPrefix(ct, "application/json") {
+		t.Fatalf("unexpected content-type: %q", ct)
+	}
+	var got map[string]string
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("response is not valid JSON: %v\nbody: %s", err, rec.Body.String())
+	}
+	if got["email"] != user.Email {
+		t.Fatalf("email round-trip failed: want %q got %q", user.Email, got["email"])
+	}
+	if got["name"] != user.Name {
+		t.Fatalf("name round-trip failed: want %q got %q", user.Name, got["name"])
+	}
+	if got["picture"] != user.Picture {
+		t.Fatalf("picture round-trip failed: want %q got %q", user.Picture, got["picture"])
+	}
+}
+
+func TestOIDCMeHandlerUnauthorized(t *testing.T) {
+	t.Parallel()
+	req := httptest.NewRequest(http.MethodGet, "/api/me", nil)
+	rec := httptest.NewRecorder()
+
+	(&OIDC{}).MeHandler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", rec.Code)
+	}
+	var got map[string]string
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("response is not valid JSON: %v\nbody: %s", err, rec.Body.String())
+	}
+	if got["error"] != "unauthorized" {
+		t.Fatalf("expected error=unauthorized, got %v", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

`OIDC.MeHandler` (`internal/auth/oidc.go:444`) and `OAuth2.MeHandler` (`internal/auth/oauth2.go:363`) build the `/api/me` JSON response by string-concatenating user fields:

```go
w.Write([]byte(`{"email":"` + u.Email + `","name":"` + u.Name + `","picture":"` + u.Picture + `"}`))
```

If any of `Email`, `Name`, or `Picture` contains a double-quote, backslash, or control character, the response becomes invalid JSON. Worse, a name like `","admin":true,"_":"` would inject arbitrary keys into the response — not currently exploitable for privilege escalation (the frontend only reads `email`/`name`/`picture`), but a sharp edge worth removing.

Concrete repro: a user whose display name is `O'Brien "the Magnificent"` (legal Unicode in real names) breaks `await res.json()` in `App.vue` and `ChatView.vue`, leaving `user.value` undefined and falling back to `window.__MANIFOLD_USER__`.

## Fix

Switch both handlers to `json.NewEncoder`. The stdlib does the escaping. Response shape is unchanged — same keys, same status codes. The only difference is a trailing `\n`, which `res.json()` handles without complaint.

```go
enc := json.NewEncoder(w)
if u, ok := CurrentUser(r.Context()); ok && u != nil {
    _ = enc.Encode(map[string]string{
        "email":   u.Email,
        "name":    u.Name,
        "picture": u.Picture,
    })
    return
}
w.WriteHeader(http.StatusUnauthorized)
_ = enc.Encode(map[string]string{"error": "unauthorized"})
```

No new dependencies; `encoding/json` was already imported in both files.

## Tests

Added 4 tests (2 per provider) in `oidc_test.go` and `oauth2_test.go`:

- `TestOIDCMeHandlerEscapesUserFields` / `TestOAuth2MeHandlerEscapesUserFields` — put quote chars in `User.Name`/`Email`/`Picture`, call the handler, assert the response is valid JSON and round-trips. Fails against the old code, passes after the fix.
- `TestOIDCMeHandlerUnauthorized` / `TestOAuth2MeHandlerUnauthorized` — 401 path returns valid JSON `{"error":"unauthorized"}`.

## Test plan

- [ ] `go test ./internal/auth/...` — 4 new tests pass alongside existing ones
- [ ] `make lint` clean
- [ ] CI green

**Note:** I don't have a Go toolchain on the machine I prepared this on, so I couldn't run the test suite locally. The change is mechanical (string-concat → `json.Encode` using already-imported stdlib), but please flag any CI failure and I'll iterate.

## Scope

Two handlers, one bug class, regression tests. No refactor, no behavior change beyond proper escaping.